### PR TITLE
feat: Assistants API

### DIFF
--- a/Demo/App/APIProvidedView.swift
+++ b/Demo/App/APIProvidedView.swift
@@ -61,6 +61,7 @@ struct APIProvidedView: View {
             let client = OpenAI(apiToken: newApiKey)
             chatStore.openAIClient = client
             imageStore.openAIClient = client
+            assistantStore.openAIClient = client
             miscStore.openAIClient = client
         }
     }

--- a/Demo/App/APIProvidedView.swift
+++ b/Demo/App/APIProvidedView.swift
@@ -13,7 +13,9 @@ struct APIProvidedView: View {
     @Binding var apiKey: String
     @StateObject var chatStore: ChatStore
     @StateObject var imageStore: ImageStore
+    @StateObject var assistantStore: AssistantStore
     @StateObject var miscStore: MiscStore
+
     @State var isShowingAPIConfigModal: Bool = true
 
     @Environment(\.idProviderValue) var idProvider
@@ -35,6 +37,12 @@ struct APIProvidedView: View {
                 openAIClient: OpenAI(apiToken: apiKey.wrappedValue)
             )
         )
+        self._assistantStore = StateObject(
+            wrappedValue: AssistantStore(
+                openAIClient: OpenAI(apiToken: apiKey.wrappedValue),
+                idProvider: idProvider
+            )
+        )
         self._miscStore = StateObject(
             wrappedValue: MiscStore(
                 openAIClient: OpenAI(apiToken: apiKey.wrappedValue)
@@ -46,6 +54,7 @@ struct APIProvidedView: View {
         ContentView(
             chatStore: chatStore,
             imageStore: imageStore,
+            assistantStore: assistantStore,
             miscStore: miscStore
         )
         .onChange(of: apiKey) { newApiKey in

--- a/Demo/App/ContentView.swift
+++ b/Demo/App/ContentView.swift
@@ -43,7 +43,7 @@ struct ContentView: View {
             .tabItem {
                 Label("Transcribe", systemImage: "mic")
             }
-            .tag(1)
+            .tag(2)
 
             ImageView(
                 store: imageStore
@@ -51,15 +51,15 @@ struct ContentView: View {
             .tabItem {
                 Label("Image", systemImage: "photo")
             }
-            .tag(2)
-            
+            .tag(3)
+
             MiscView(
                 store: miscStore
             )
             .tabItem {
                 Label("Misc", systemImage: "ellipsis")
             }
-            .tag(3)
+            .tag(4)
         }
     }
 }

--- a/Demo/App/ContentView.swift
+++ b/Demo/App/ContentView.swift
@@ -12,19 +12,31 @@ import SwiftUI
 struct ContentView: View {
     @ObservedObject var chatStore: ChatStore
     @ObservedObject var imageStore: ImageStore
+    @ObservedObject var assistantStore: AssistantStore
     @ObservedObject var miscStore: MiscStore
+    
     @State private var selectedTab = 0
     @Environment(\.idProviderValue) var idProvider
 
     var body: some View {
         TabView(selection: $selectedTab) {
             ChatView(
-                store: chatStore
+                store: chatStore,
+                assistantStore: assistantStore
             )
             .tabItem {
                 Label("Chats", systemImage: "message")
             }
             .tag(0)
+
+            AssistantsView(
+                store: chatStore,
+                assistantStore: assistantStore
+            )
+            .tabItem {
+                Label("Assistants", systemImage: "eyeglasses")
+            }
+            .tag(1)
 
             TranscribeView(
             )
@@ -49,13 +61,6 @@ struct ContentView: View {
             }
             .tag(3)
         }
-    }
-}
-
-struct ChatsView: View {
-    var body: some View {
-        Text("Chats")
-            .font(.largeTitle)
     }
 }
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -284,6 +285,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -299,6 +301,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72WEN2C47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -311,7 +314,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
@@ -336,6 +339,7 @@
 				CODE_SIGN_ENTITLEMENTS = App/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 72WEN2C47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -348,7 +352,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.3;

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -301,7 +301,6 @@
 				CODE_SIGN_ENTITLEMENTS = App/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 72WEN2C47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -339,7 +338,6 @@
 				CODE_SIGN_ENTITLEMENTS = App/Demo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 72WEN2C47N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/Demo/DemoChat/Sources/AssistantStore.swift
+++ b/Demo/DemoChat/Sources/AssistantStore.swift
@@ -1,0 +1,94 @@
+//
+//  ChatStore.swift
+//  DemoChat
+//
+//  Created by Sihao Lu on 3/25/23.
+//
+
+import Foundation
+import Combine
+import OpenAI
+
+public final class AssistantStore: ObservableObject {
+    public var openAIClient: OpenAIProtocol
+    let idProvider: () -> String
+    @Published var selectedAssistantId: String?
+
+    @Published var availableAssistants: [Assistant] = []
+
+    public init(
+        openAIClient: OpenAIProtocol,
+        idProvider: @escaping () -> String
+    ) {
+        self.openAIClient = openAIClient
+        self.idProvider = idProvider
+    }
+
+    // MARK: Models
+
+    @MainActor
+    func createAssistant(name: String, description: String, instructions: String, codeInterpreter: Bool, retrievel: Bool, fileIds: [String]? = nil) async -> String? {
+        do {
+            var tools = [Tool]()
+            if codeInterpreter {
+                tools.append(Tool(toolType: "code_interpreter"))
+            }
+            if retrievel {
+                tools.append(Tool(toolType: "retrieval"))
+            }
+
+            // TODO: Replace with actual gpt-4-1106-preview model.
+            let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: name, description: description, instructions: instructions, tools:tools, fileIds: fileIds)
+            let response = try await openAIClient.assistants(query: query, method: "POST")
+
+            // Returns assistantId
+            return response.id
+
+        } catch {
+            // TODO: Better error handling
+            print(error.localizedDescription)
+        }
+        return nil
+    }
+
+    @MainActor
+    func getAssistants(limit: Int) async -> [Assistant] {
+        do {
+            let response = try await openAIClient.assistants(query: nil, method: "GET")
+
+            var assistants = [Assistant]()
+            for result in response.data ?? [] {
+                let codeInterpreter = response.tools?.filter { $0.toolType == "code_interpreter" }.first != nil
+                let retrieval = response.tools?.filter { $0.toolType == "retrieval" }.first != nil
+
+                assistants.append(Assistant(id: result.id, name: result.name, description: result.description, instructions: result.instructions, codeInterpreter: codeInterpreter, retrieval: retrieval))
+            }
+            availableAssistants = assistants
+            return assistants
+
+        } catch {
+            // TODO: Better error handling
+            print(error.localizedDescription)
+        }
+        return []
+    }
+
+    func selectAssistant(_ assistantId: String?) {
+        selectedAssistantId = assistantId
+    }
+
+    @MainActor
+    func uploadFile(url: URL) async -> String? {
+        do {
+            let fileData = try Data(contentsOf: url)
+
+            // TODO: Support all the same types as openAI (not just pdf).
+            let result = try await openAIClient.files(query: FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: "application/pdf"))
+            return result.id
+        }
+        catch {
+            print("error = \(error)")
+            return nil
+        }
+    }
+}

--- a/Demo/DemoChat/Sources/AssistantStore.swift
+++ b/Demo/DemoChat/Sources/AssistantStore.swift
@@ -96,7 +96,7 @@ public final class AssistantStore: ObservableObject {
     }
 
     @MainActor
-    func uploadFile(url: URL) async -> String? {
+    func uploadFile(url: URL) async -> FilesResult? {
         do {
 
             let mimeType = url.mimeType()
@@ -104,7 +104,7 @@ public final class AssistantStore: ObservableObject {
             let fileData = try Data(contentsOf: url)
 
             let result = try await openAIClient.files(query: FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: mimeType))
-            return result.id
+            return result
         }
         catch {
             print("error = \(error)")

--- a/Demo/DemoChat/Sources/ChatStore.swift
+++ b/Demo/DemoChat/Sources/ChatStore.swift
@@ -245,6 +245,12 @@ public final class ChatStore: ObservableObject {
 
         Task {
             let result = try await openAIClient.runRetrieve(threadId: currentThreadId ?? "", runId: currentRunId ?? "")
+            
+            // TESTING RETRIEVAL OF RUN STEPS
+            Task {
+                let stepsResult = try await openAIClient.runRetrieveSteps(threadId: currentThreadId ?? "", runId: currentRunId ?? "")
+               // print(stepsResult)
+            }
 
             switch result.status {
             // Get threadsMesages.

--- a/Demo/DemoChat/Sources/Models/Assistant.swift
+++ b/Demo/DemoChat/Sources/Models/Assistant.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 struct Assistant: Hashable {
-    init(id: String, name: String, description: String? = nil, instructions: String? = nil, codeInterpreter: Bool, retrieval: Bool) {
+    init(id: String, name: String, description: String? = nil, instructions: String? = nil, codeInterpreter: Bool, retrieval: Bool, fileIds: [String]? = nil) {
         self.id = id
         self.name = name
         self.description = description
         self.instructions = instructions
         self.codeInterpreter = codeInterpreter
         self.retrieval = retrieval
+        self.fileIds = fileIds
     }
     
     typealias ID = String
@@ -23,7 +24,7 @@ struct Assistant: Hashable {
     let name: String
     let description: String?
     let instructions: String?
-
+    let fileIds: [String]?
     var codeInterpreter: Bool
     var retrieval: Bool
 }

--- a/Demo/DemoChat/Sources/Models/Assistant.swift
+++ b/Demo/DemoChat/Sources/Models/Assistant.swift
@@ -1,0 +1,32 @@
+//
+//  Conversation.swift
+//  DemoChat
+//
+//  Created by Sihao Lu on 3/25/23.
+//
+
+import Foundation
+
+struct Assistant: Hashable {
+    init(id: String, name: String, description: String? = nil, instructions: String? = nil, codeInterpreter: Bool, retrieval: Bool) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.instructions = instructions
+        self.codeInterpreter = codeInterpreter
+        self.retrieval = retrieval
+    }
+    
+    typealias ID = String
+    
+    let id: String
+    let name: String
+    let description: String?
+    let instructions: String?
+
+    var codeInterpreter: Bool
+    var retrieval: Bool
+}
+
+
+extension Assistant: Equatable, Identifiable {}

--- a/Demo/DemoChat/Sources/Models/Conversation.swift
+++ b/Demo/DemoChat/Sources/Models/Conversation.swift
@@ -8,15 +8,24 @@
 import Foundation
 
 struct Conversation {
-    init(id: String, messages: [Message] = []) {
+    init(id: String, messages: [Message] = [], type: ConversationType = .normal, assistantId: String? = nil) {
         self.id = id
         self.messages = messages
+        self.type = type
+        self.assistantId = assistantId
     }
     
     typealias ID = String
     
     let id: String
     var messages: [Message]
+    var type: ConversationType
+    var assistantId: String?
+}
+
+enum ConversationType {
+    case normal
+    case assistant
 }
 
 extension Conversation: Equatable, Identifiable {}

--- a/Demo/DemoChat/Sources/Models/Message.swift
+++ b/Demo/DemoChat/Sources/Models/Message.swift
@@ -13,6 +13,9 @@ struct Message {
     var role: Chat.Role
     var content: String
     var createdAt: Date
+
+    var isLocal: Bool?
+
 }
 
 extension Message: Equatable, Codable, Hashable, Identifiable {}

--- a/Demo/DemoChat/Sources/Models/Message.swift
+++ b/Demo/DemoChat/Sources/Models/Message.swift
@@ -15,7 +15,7 @@ struct Message {
     var createdAt: Date
 
     var isLocal: Bool?
-
+    var isRunStep: Bool?
 }
 
 extension Message: Equatable, Codable, Hashable, Identifiable {}

--- a/Demo/DemoChat/Sources/SupportedFileType.swift
+++ b/Demo/DemoChat/Sources/SupportedFileType.swift
@@ -1,0 +1,92 @@
+//
+//  SupportedFileType.swift
+//
+//
+//  Created by Chris Dillard on 12/8/23.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+struct SupportedFileType {
+    let fileFormat: String
+    let mimeType: String
+    let isCodeInterpreterSupported: Bool
+    let isRetrievalSupported: Bool
+}
+
+let supportedFileTypes: [SupportedFileType] = [
+    SupportedFileType(fileFormat: "c",    mimeType: "text/x-c",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "cpp",  mimeType: "text/x-c++",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "csv",  mimeType: "application/csv",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "docx", mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "html", mimeType: "text/html",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "java", mimeType: "text/x-java",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "json", mimeType: "application/json",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "md",   mimeType: "text/markdown",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "pdf",  mimeType: "application/pdf",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "php",  mimeType: "text/x-php",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "pptx", mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "py",   mimeType: "text/x-python",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "rb",   mimeType: "text/x-ruby",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "tex",  mimeType: "text/x-tex",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "txt",  mimeType: "text/plain",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: true),
+    SupportedFileType(fileFormat: "css",  mimeType: "text/css",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "jpeg", mimeType: "image/jpeg",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "jpg",  mimeType: "image/jpeg",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "js",   mimeType: "text/javascript",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "gif",  mimeType: "image/gif",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "png",  mimeType: "image/png",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "tar",  mimeType: "application/x-tar",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "ts",   mimeType: "application/typescript",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "xlsx", mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "xml",  mimeType: "application/xml", // or \"text/xml\"
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false),
+    SupportedFileType(fileFormat: "zip",  mimeType: "application/zip",
+                      isCodeInterpreterSupported: true, isRetrievalSupported: false)
+]
+
+func supportedUITypes() -> [UTType] {
+    var supportedTypes: [UTType] = []
+    
+    for supportedFileType in supportedFileTypes {
+        if let newType = UTType(filenameExtension: supportedFileType.fileFormat) {
+            supportedTypes += [newType]
+        }
+    }
+
+    return supportedTypes
+}
+
+extension URL {
+    func mimeType() -> String {
+        guard let utType = UTType(filenameExtension: self.pathExtension) else {
+            return "application/octet-stream" // Default type if unknown
+        }
+        return utType.preferredMIMEType ?? "application/octet-stream"
+    }
+}

--- a/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
@@ -8,6 +8,11 @@
 import SwiftUI
 
 struct AssistantModalContentView: View {
+    enum Mode {
+        case modify
+        case create
+    }
+
     @Binding var name: String
     @Binding var description: String
     @Binding var customInstructions: String
@@ -15,14 +20,15 @@ struct AssistantModalContentView: View {
     @Binding var codeInterpreter: Bool
     @Binding var retrieval: Bool
     @Binding var fileIds: [String]
+    @Binding var isUploading: Bool
 
     var modify: Bool
 
     @Environment(\.dismiss) var dismiss
 
     @Binding var isPickerPresented: Bool
+    // If a file has been selected for uploading and is currently in progress, this is set.
     @Binding var selectedFileURL: URL?
-    
 
     var onCommit: () -> Void
     var onFileUpload: () -> Void
@@ -49,6 +55,16 @@ struct AssistantModalContentView: View {
                 Toggle(isOn: $retrieval, label: {
                     Text("Retrieval")
                 })
+
+                if !fileIds.isEmpty {
+                    ForEach(fileIds, id: \.self) { url in
+                        HStack {
+                            Text("File: \(url)")
+
+                        }
+                    }
+                }
+
                 if let selectedFileURL {
                     HStack {
                         Text("File: \(selectedFileURL.lastPathComponent)")

--- a/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
@@ -1,0 +1,85 @@
+//
+//  AssistantModalContentView.swift
+//
+//
+//  Created by Chris Dillard on 11/9/23.
+//
+
+import SwiftUI
+
+struct AssistantModalContentView: View {
+    @Binding var name: String
+    @Binding var description: String
+    @Binding var customInstructions: String
+
+    @Binding var codeInterpreter: Bool
+    @Binding var retrieval: Bool
+
+    var modify: Bool
+
+    @Environment(\.dismiss) var dismiss
+
+    @Binding var isPickerPresented: Bool
+    @Binding var selectedFileURL: URL?
+    
+
+    var onCommit: () -> Void
+    var onFileUpload: () -> Void
+
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Name")) {
+                    TextField("Name", text: $name)
+                }
+                Section(header: Text("Description")) {
+                    TextEditor(text: $description)
+                        .frame(minHeight: 50)
+                }
+                Section(header: Text("Custom Instructions")) {
+                    TextEditor(text: $customInstructions)
+                        .frame(minHeight: 100)
+                }
+
+                Toggle(isOn: $codeInterpreter, label: {
+                    Text("Code interpreter")
+                })
+
+                Toggle(isOn: $retrieval, label: {
+                    Text("Retrieval")
+                })
+                if let selectedFileURL {
+                    HStack {
+                        Text("File: \(selectedFileURL.lastPathComponent)")
+
+                        Button("Remove") {
+                            self.selectedFileURL = nil
+                        }
+                    }
+                }
+                else {
+                    Button("Upload File") {
+                        isPickerPresented = true
+                    }
+                    .sheet(isPresented: $isPickerPresented) {
+                        DocumentPicker { url in
+                            selectedFileURL = url
+                            onFileUpload()
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Enter Assistant Details")
+            .navigationBarItems(
+                leading: Button("Cancel") {
+                    dismiss()
+                },
+                trailing: Button("OK") {
+                    onCommit()
+                    dismiss()
+                }
+            )
+        }
+    }
+}

--- a/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
@@ -14,6 +14,7 @@ struct AssistantModalContentView: View {
 
     @Binding var codeInterpreter: Bool
     @Binding var retrieval: Bool
+    @Binding var fileIds: [String]
 
     var modify: Bool
 
@@ -25,7 +26,6 @@ struct AssistantModalContentView: View {
 
     var onCommit: () -> Void
     var onFileUpload: () -> Void
-
 
     var body: some View {
         NavigationView {
@@ -70,7 +70,7 @@ struct AssistantModalContentView: View {
                     }
                 }
             }
-            .navigationTitle("Enter Assistant Details")
+            .navigationTitle("\(modify ? "Edit" : "Enter") Assistant Details")
             .navigationBarItems(
                 leading: Button("Cancel") {
                     dismiss()

--- a/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantModalContentView.swift
@@ -57,10 +57,21 @@ struct AssistantModalContentView: View {
                 })
 
                 if !fileIds.isEmpty {
-                    ForEach(fileIds, id: \.self) { url in
+                    ForEach(fileIds, id: \.self) { fileId in
                         HStack {
-                            Text("File: \(url)")
-
+                            // File Id of each file added to the assistant.
+                            Text("File: \(fileId)")
+                            Spacer()
+                            // Button to remove fileId from the list of fileIds to be used when create or modify assistant.
+                            Button(action: {
+                                // Add action to remove the file from the list
+                                if let index = fileIds.firstIndex(of: fileId) {
+                                    fileIds.remove(at: index)
+                                }
+                            }) {
+                                Image(systemName: "xmark.circle.fill") // X button
+                                    .foregroundColor(.red)
+                            }
                         }
                     }
                 }

--- a/Demo/DemoChat/Sources/UI/AssistantsListView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsListView.swift
@@ -8,20 +8,34 @@
 import SwiftUI
 
 struct AssistantsListView: View {
-    @Binding var conversations: [Assistant]
+    @Binding var assistants: [Assistant]
     @Binding var selectedAssistantId: String?
+    var onLoadMoreAssistants: () -> Void
+    @Binding var isLoadingMore: Bool
 
     var body: some View {
-        List(
-            $conversations,
-            editActions: [.delete],
-            selection: $selectedAssistantId
-        ) { $conversation in
+        VStack {
+            List(
+                $assistants,
+                editActions: [.delete],
+                selection: $selectedAssistantId
+            ) { $assistant in
                 Text(
-                    conversation.name
+                    assistant.name
                 )
                 .lineLimit(2)
+                .onAppear {
+                    if assistant.id == assistants.last?.id {
+                        onLoadMoreAssistants()
+                    }
+                }
+            }
 
+
+            if isLoadingMore {
+                ProgressView()
+                    .padding()
+            }
         }
         .navigationTitle("Assistants")
     }

--- a/Demo/DemoChat/Sources/UI/AssistantsListView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsListView.swift
@@ -1,0 +1,28 @@
+//
+//  ListView.swift
+//  DemoChat
+//
+//  Created by Sihao Lu on 3/25/23.
+//
+
+import SwiftUI
+
+struct AssistantsListView: View {
+    @Binding var conversations: [Assistant]
+    @Binding var selectedAssistantId: String?
+
+    var body: some View {
+        List(
+            $conversations,
+            editActions: [.delete],
+            selection: $selectedAssistantId
+        ) { $conversation in
+                Text(
+                    conversation.name
+                )
+                .lineLimit(2)
+
+        }
+        .navigationTitle("Assistants")
+    }
+}

--- a/Demo/DemoChat/Sources/UI/AssistantsView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsView.swift
@@ -11,37 +11,37 @@ import SwiftUI
 public struct AssistantsView: View {
     @ObservedObject var store: ChatStore
     @ObservedObject var assistantStore: AssistantStore
-    
+
     @Environment(\.dateProviderValue) var dateProvider
     @Environment(\.idProviderValue) var idProvider
-    
+
     // state to select file
     @State private var isPickerPresented: Bool = false
     @State private var fileURL: URL?
-    
+
     // state to modify assistant
     @State private var name: String = ""
     @State private var description: String = ""
     @State private var customInstructions: String = ""
     @State private var fileIds: [String] = []
-    
+
     @State private var codeInterpreter: Bool = false
     @State private var retrieval: Bool = false
     @State var isLoadingMore = false
     @State private var isModalPresented = false
     @State private var isUploading = false
-    
+
     //If a file is selected via the document picker, this is set.
     @State var selectedFileURL: URL?
     @State var uploadedFileId: String?
-    
+
     @State var mode: AssistantModalContentView.Mode = .create
-    
+
     public init(store: ChatStore, assistantStore: AssistantStore) {
         self.store = store
         self.assistantStore = assistantStore
     }
-    
+
     public var body: some View {
         ZStack {
             NavigationSplitView {
@@ -49,24 +49,11 @@ public struct AssistantsView: View {
                     assistants: $assistantStore.availableAssistants, selectedAssistantId: Binding<String?>(
                         get: {
                             assistantStore.selectedAssistantId
-                            
+
                         }, set: { newId in
                             guard newId != nil else { return }
-                            
-                            assistantStore.selectAssistant(newId)
-                            
-                            let selectedAssistant = assistantStore.availableAssistants.filter { $0.id == assistantStore.selectedAssistantId }.first
-                            
-                            name = selectedAssistant?.name ?? ""
-                            description = selectedAssistant?.description ?? ""
-                            customInstructions = selectedAssistant?.instructions ?? ""
-                            codeInterpreter = selectedAssistant?.codeInterpreter ?? false
-                            retrieval = selectedAssistant?.retrieval ?? false
-                            fileIds = selectedAssistant?.fileIds ?? []
-                            
-                            mode = .modify
-                            isModalPresented = true
-                            
+
+                            selectAssistant(newId: newId)
                         }), onLoadMoreAssistants: {
                             loadMoreAssistants()
                         }, isLoadingMore: $isLoadingMore
@@ -88,29 +75,30 @@ public struct AssistantsView: View {
                         } label: {
                             Image(systemName: "plus")
                         }
-                        
+
                         .buttonStyle(.borderedProminent)
                     }
                 }
             } detail: {
-                
+
             }
             .sheet(isPresented: $isModalPresented, onDismiss: {
                 resetAssistantCreator()
             }, content: {
                 AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
-                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds, isUploading: $isUploading, modify: mode == .modify, isPickerPresented: $isPickerPresented, selectedFileURL: $selectedFileURL) {
+                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds,
+                                          isUploading: $isUploading, modify: mode == .modify, isPickerPresented: $isPickerPresented, selectedFileURL: $selectedFileURL) {
                     Task {
                         await handleOKTap()
                     }
                 } onFileUpload: {
                     Task {
                         guard let selectedFileURL  else { return }
-                        
+
                         isUploading = true
                         uploadedFileId = await assistantStore.uploadFile(url: selectedFileURL)
                         isUploading = false
-                        
+
                         if uploadedFileId == nil {
                             print("Failed to upload")
                             self.selectedFileURL = nil
@@ -119,9 +107,9 @@ public struct AssistantsView: View {
                             // if successful upload , we can show it.
                             if let uploadedFileId = uploadedFileId {
                                 self.selectedFileURL = nil
-                                
+
                                 fileIds += [uploadedFileId]
-                                
+
                                 print("Successful upload!")
                             }
                         }
@@ -130,58 +118,78 @@ public struct AssistantsView: View {
             })
         }
     }
-    
-    func handleOKTap() async {
-        // When OK is tapped that means we should save the modified assistant and start a new thread with it.
+
+    private func handleOKTap() async {
+
         var mergedFileIds = [String]()
-        
+
         mergedFileIds += fileIds
-        
+
         let asstId: String?
-        
-        if mode == .create {
+
+        switch mode {
+            // Create new Assistant and start a new conversation with it.
+        case .create:
             asstId = await assistantStore.createAssistant(name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: mergedFileIds.isEmpty ? nil : mergedFileIds)
-        }
-        // Modify
-        else {
+            // Modify existing Assistant and start new conversation with it.
+        case .modify:
             guard let selectedAssistantId = assistantStore.selectedAssistantId else { return print("Cannot modify assistant, not selected.") }
-            
+
             asstId = await assistantStore.modifyAssistant(asstId: selectedAssistantId, name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: mergedFileIds.isEmpty ? nil : mergedFileIds)
         }
-        
+
+        // Reset Assistant Creator after attempted creation or modification.
+        resetAssistantCreator()
+
         guard let asstId else {
             print("failed to create Assistant.")
             return
         }
-        
-        resetAssistantCreator()
-        
+
+        // Create new local conversation to represent new thread.
         store.createConversation(type: .assistant, assistantId: asstId)
     }
-    
-    func loadMoreAssistants() {
+
+    private func loadMoreAssistants() {
         guard !isLoadingMore else { return }
-        
+
         isLoadingMore = true
         let lastAssistantId = assistantStore.availableAssistants.last?.id ?? ""
-        
+
         Task {
             // Fetch more assistants and append to the list
             let _ = await assistantStore.getAssistants(after: lastAssistantId)
             isLoadingMore = false
         }
     }
-    
-    func resetAssistantCreator() {
+
+    private func resetAssistantCreator() {
         // Reset state for Assistant creator.
         name = ""
         description = ""
         customInstructions = ""
-        
+
         codeInterpreter = false
         retrieval = false
         selectedFileURL = nil
         uploadedFileId = nil
         fileIds = []
+    }
+
+    private func selectAssistant(newId: String?) {
+        assistantStore.selectAssistant(newId)
+
+        let selectedAssistant = assistantStore.availableAssistants.filter { $0.id == assistantStore.selectedAssistantId }.first
+
+        name = selectedAssistant?.name ?? ""
+        description = selectedAssistant?.description ?? ""
+        customInstructions = selectedAssistant?.instructions ?? ""
+        codeInterpreter = selectedAssistant?.codeInterpreter ?? false
+        retrieval = selectedAssistant?.retrieval ?? false
+        fileIds = selectedAssistant?.fileIds ?? []
+
+        mode = .modify
+        isModalPresented = true
+
     }
 }

--- a/Demo/DemoChat/Sources/UI/AssistantsView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsView.swift
@@ -11,31 +11,37 @@ import SwiftUI
 public struct AssistantsView: View {
     @ObservedObject var store: ChatStore
     @ObservedObject var assistantStore: AssistantStore
-
+    
     @Environment(\.dateProviderValue) var dateProvider
     @Environment(\.idProviderValue) var idProvider
-
+    
     // state to select file
     @State private var isPickerPresented: Bool = false
     @State private var fileURL: URL?
-    @State private var uploadedFileId: String?
-
+    
     // state to modify assistant
     @State private var name: String = ""
     @State private var description: String = ""
     @State private var customInstructions: String = ""
     @State private var fileIds: [String] = []
-
+    
     @State private var codeInterpreter: Bool = false
     @State private var retrieval: Bool = false
     @State var isLoadingMore = false
     @State private var isModalPresented = false
-
+    @State private var isUploading = false
+    
+    //If a file is selected via the document picker, this is set.
+    @State var selectedFileURL: URL?
+    @State var uploadedFileId: String?
+    
+    @State var mode: AssistantModalContentView.Mode = .create
+    
     public init(store: ChatStore, assistantStore: AssistantStore) {
         self.store = store
         self.assistantStore = assistantStore
     }
-
+    
     public var body: some View {
         ZStack {
             NavigationSplitView {
@@ -43,22 +49,24 @@ public struct AssistantsView: View {
                     assistants: $assistantStore.availableAssistants, selectedAssistantId: Binding<String?>(
                         get: {
                             assistantStore.selectedAssistantId
-
+                            
                         }, set: { newId in
                             guard newId != nil else { return }
-
+                            
                             assistantStore.selectAssistant(newId)
-
+                            
                             let selectedAssistant = assistantStore.availableAssistants.filter { $0.id == assistantStore.selectedAssistantId }.first
-
+                            
                             name = selectedAssistant?.name ?? ""
                             description = selectedAssistant?.description ?? ""
                             customInstructions = selectedAssistant?.instructions ?? ""
                             codeInterpreter = selectedAssistant?.codeInterpreter ?? false
                             retrieval = selectedAssistant?.retrieval ?? false
+                            fileIds = selectedAssistant?.fileIds ?? []
                             
+                            mode = .modify
                             isModalPresented = true
-
+                            
                         }), onLoadMoreAssistants: {
                             loadMoreAssistants()
                         }, isLoadingMore: $isLoadingMore
@@ -73,64 +81,107 @@ public struct AssistantsView: View {
                                     let _ = await assistantStore.getAssistants()
                                 }
                             }
+                            Button("Create Assistant") {
+                                mode = .create
+                                isModalPresented = true
+                            }
                         } label: {
                             Image(systemName: "plus")
                         }
-
+                        
                         .buttonStyle(.borderedProminent)
                     }
                 }
             } detail: {
-
+                
             }
-            .sheet(isPresented: $isModalPresented) {
-                if let _ = assistantStore.selectedAssistantId {
-                    AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
-                                              codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds, modify: true, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
-                        Task {
-                            await handleOKTap()
+            .sheet(isPresented: $isModalPresented, onDismiss: {
+                resetAssistantCreator()
+            }, content: {
+                AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
+                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds, isUploading: $isUploading, modify: mode == .modify, isPickerPresented: $isPickerPresented, selectedFileURL: $selectedFileURL) {
+                    Task {
+                        await handleOKTap()
+                    }
+                } onFileUpload: {
+                    Task {
+                        guard let selectedFileURL  else { return }
+                        
+                        isUploading = true
+                        uploadedFileId = await assistantStore.uploadFile(url: selectedFileURL)
+                        isUploading = false
+                        
+                        if uploadedFileId == nil {
+                            print("Failed to upload")
+                            self.selectedFileURL = nil
                         }
-                    } onFileUpload: {
-                        Task {
-                            guard let fileURL else { return }
-
-                            uploadedFileId = await assistantStore.uploadFile(url: fileURL)
+                        else {
+                            // if successful upload , we can show it.
+                            if let uploadedFileId = uploadedFileId {
+                                self.selectedFileURL = nil
+                                
+                                fileIds += [uploadedFileId]
+                                
+                                print("Successful upload!")
+                            }
                         }
                     }
                 }
-            }
+            })
         }
     }
-
+    
     func handleOKTap() async {
-        guard let selectedAssistantId = assistantStore.selectedAssistantId else { return print("Cannot modify assistant, not selected.") }
-
         // When OK is tapped that means we should save the modified assistant and start a new thread with it.
-        var fileIds = [String]()
-        if let fileId = uploadedFileId {
-            fileIds.append(fileId)
+        var mergedFileIds = [String]()
+        
+        mergedFileIds += fileIds
+        
+        let asstId: String?
+        
+        if mode == .create {
+            asstId = await assistantStore.createAssistant(name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: mergedFileIds.isEmpty ? nil : mergedFileIds)
         }
-
-        let asstId = await assistantStore.modifyAssistant(asstId: selectedAssistantId, name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: fileIds.isEmpty ? nil : fileIds)
-
+        // Modify
+        else {
+            guard let selectedAssistantId = assistantStore.selectedAssistantId else { return print("Cannot modify assistant, not selected.") }
+            
+            asstId = await assistantStore.modifyAssistant(asstId: selectedAssistantId, name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: mergedFileIds.isEmpty ? nil : mergedFileIds)
+        }
+        
         guard let asstId else {
             print("failed to create Assistant.")
             return
         }
-
+        
+        resetAssistantCreator()
+        
         store.createConversation(type: .assistant, assistantId: asstId)
     }
-
+    
     func loadMoreAssistants() {
         guard !isLoadingMore else { return }
-
+        
         isLoadingMore = true
         let lastAssistantId = assistantStore.availableAssistants.last?.id ?? ""
-
+        
         Task {
             // Fetch more assistants and append to the list
             let _ = await assistantStore.getAssistants(after: lastAssistantId)
             isLoadingMore = false
         }
+    }
+    
+    func resetAssistantCreator() {
+        // Reset state for Assistant creator.
+        name = ""
+        description = ""
+        customInstructions = ""
+        
+        codeInterpreter = false
+        retrieval = false
+        selectedFileURL = nil
+        uploadedFileId = nil
+        fileIds = []
     }
 }

--- a/Demo/DemoChat/Sources/UI/AssistantsView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsView.swift
@@ -1,0 +1,114 @@
+//
+//  ChatView.swift
+//  DemoChat
+//
+//  Created by Sihao Lu on 3/25/23.
+//
+
+import Combine
+import SwiftUI
+
+public struct AssistantsView: View {
+    @ObservedObject var store: ChatStore
+    @ObservedObject var assistantStore: AssistantStore
+
+    @Environment(\.dateProviderValue) var dateProvider
+    @Environment(\.idProviderValue) var idProvider
+
+    // state to select file
+    @State private var isPickerPresented: Bool = false
+    @State private var fileURL: URL?
+    @State private var uploadedFileId: String?
+
+    // state to modify assistant
+    @State private var name: String = ""
+    @State private var description: String = ""
+    @State private var customInstructions: String = ""
+
+    @State private var codeInterpreter: Bool = false
+    @State private var retrieval: Bool = false
+
+    public init(store: ChatStore, assistantStore: AssistantStore) {
+        self.store = store
+        self.assistantStore = assistantStore
+    }
+
+    public var body: some View {
+        ZStack {
+            NavigationSplitView {
+                AssistantsListView(
+                    conversations: $assistantStore.availableAssistants, selectedAssistantId: Binding<String?>(
+                        get: {
+                            assistantStore.selectedAssistantId
+
+                        }, set: { newId in
+                            assistantStore.selectAssistant(newId)
+
+                            let selectedAssistant = assistantStore.availableAssistants.filter { $0.id == assistantStore.selectedAssistantId }.first
+
+                            name = selectedAssistant?.name ?? ""
+                            description = selectedAssistant?.description ?? ""
+                            customInstructions = selectedAssistant?.instructions ?? ""
+                            codeInterpreter = selectedAssistant?.codeInterpreter ?? false
+                            retrieval = selectedAssistant?.retrieval ?? false
+
+
+                        })
+                )
+                .toolbar {
+                    ToolbarItem(
+                        placement: .primaryAction
+                    ) {
+                        Menu {
+                            Button("Get Assistants") {
+                                Task {
+                                    let _ = await assistantStore.getAssistants(limit: 20)
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+
+                        .buttonStyle(.borderedProminent)
+                    }
+                }
+            } detail: {
+                // TODO: Allow modifying Assistant.
+                if let selectedAssistantId = assistantStore.selectedAssistantId {
+
+
+                    AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
+                                              codeInterpreter: $codeInterpreter, retrieval: $retrieval, modify: true, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
+                        Task {
+                            await handleOKTap()
+                        }
+                    } onFileUpload: {
+                        Task {
+                            guard let fileURL else { return }
+
+                            uploadedFileId = await assistantStore.uploadFile(url: fileURL)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func handleOKTap() async {
+
+        // When OK is tapped that means we should save the modified assistant and start a new thread.
+        var fileIds = [String]()
+        if let fileId = uploadedFileId {
+            fileIds.append(fileId)
+        }
+
+        let asstId = await assistantStore.createAssistant(name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: fileIds.isEmpty ? nil : fileIds)
+
+        guard let asstId else {
+            print("failed to create Assistant.")
+            return
+        }
+
+        store.createConversation(type: .assistant, assistantId: asstId)
+    }
+}

--- a/Demo/DemoChat/Sources/UI/AssistantsView.swift
+++ b/Demo/DemoChat/Sources/UI/AssistantsView.swift
@@ -96,7 +96,8 @@ public struct AssistantsView: View {
                         guard let selectedFileURL  else { return }
 
                         isUploading = true
-                        uploadedFileId = await assistantStore.uploadFile(url: selectedFileURL)
+                        let file = await assistantStore.uploadFile(url: selectedFileURL)
+                        uploadedFileId =  file?.id
                         isUploading = false
 
                         if uploadedFileId == nil {

--- a/Demo/DemoChat/Sources/UI/ChatView.swift
+++ b/Demo/DemoChat/Sources/UI/ChatView.swift
@@ -10,58 +10,129 @@ import SwiftUI
 
 public struct ChatView: View {
     @ObservedObject var store: ChatStore
-    
+    @ObservedObject var assistantStore: AssistantStore
+
     @Environment(\.dateProviderValue) var dateProvider
     @Environment(\.idProviderValue) var idProvider
 
-    public init(store: ChatStore) {
+
+    @State private var isModalPresented = false
+    @State private var name: String = ""
+    @State private var description: String = ""
+    @State private var customInstructions: String = ""
+
+    @State private var codeInterpreter: Bool = false
+    @State private var retrieval: Bool = false
+
+
+    @State private var isPickerPresented: Bool = false
+    @State private var fileURL: URL?
+    @State private var uploadedFileId: String?
+
+
+    public init(store: ChatStore, assistantStore: AssistantStore) {
         self.store = store
+        self.assistantStore = assistantStore
     }
-    
+
     public var body: some View {
-        NavigationSplitView {
-            ListView(
-                conversations: $store.conversations,
-                selectedConversationId: Binding<Conversation.ID?>(
-                    get: {
-                    store.selectedConversationID
-                }, set: { newId in
-                    store.selectConversation(newId)
-                })
-            )
-            .toolbar {
-                ToolbarItem(
-                    placement: .primaryAction
-                ) {
-                    Button(action: {
-                        store.createConversation()
-                    }) {
-                        Image(systemName: "plus")
+        ZStack {
+            NavigationSplitView {
+                ListView(
+                    conversations: $store.conversations,
+                    selectedConversationId: Binding<Conversation.ID?>(
+                        get: {
+                            store.selectedConversationID
+                        }, set: { newId in
+                            store.selectConversation(newId)
+                        })
+                )
+                .toolbar {
+                    ToolbarItem(
+                        placement: .primaryAction
+                    ) {
+
+                        Menu {
+                            Button("Create Chat") {
+                                store.createConversation()
+
+                            }
+                            Button("Create Assistant") {
+                                isModalPresented = true
+
+                            }
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+
+                        .buttonStyle(.borderedProminent)
                     }
-                    .buttonStyle(.borderedProminent)
+                }
+            } detail: {
+                if let conversation = store.selectedConversation {
+                    DetailView(
+                        availableAssistants: assistantStore.availableAssistants, conversation: conversation,
+                        error: store.conversationErrors[conversation.id],
+                        sendMessage: { message, selectedModel in
+                            Task {
+                                await store.sendMessage(
+                                    Message(
+                                        id: idProvider(),
+                                        role: .user,
+                                        content: message,
+                                        createdAt: dateProvider()
+                                    ),
+                                    conversationId: conversation.id,
+                                    model: selectedModel
+                                )
+                            }
+                        }, isSendingMessage: $store.isSendingMessage
+                    )
                 }
             }
-        } detail: {
-            if let conversation = store.selectedConversation {
-                DetailView(
-                    conversation: conversation,
-                    error: store.conversationErrors[conversation.id],
-                    sendMessage: { message, selectedModel in
-                        Task {
-                            await store.sendMessage(
-                                Message(
-                                    id: idProvider(),
-                                    role: .user,
-                                    content: message,
-                                    createdAt: dateProvider()
-                                ),
-                                conversationId: conversation.id,
-                                model: selectedModel
-                            )
+            .sheet(isPresented: $isModalPresented) {
+                AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
+                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, modify: false, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
+                    Task {
+                        await handleOKTap()
+                    }
+                } onFileUpload: {
+                    Task {
+                        guard let fileURL else { return }
+
+                        uploadedFileId = await assistantStore.uploadFile(url: fileURL)
+                        if uploadedFileId == nil {
+                            print("Failed to upload")
                         }
                     }
-                )
+                }
             }
         }
+    }
+    func handleOKTap() async {
+        
+        // Reset state for Assistant creator.
+        name = ""
+        description = ""
+        customInstructions = ""
+
+        codeInterpreter = false
+        retrieval = false
+        fileURL = nil
+        uploadedFileId = nil
+        
+        var fileIds = [String]()
+        if let fileId = uploadedFileId {
+            fileIds.append(fileId)
+        }
+
+        let asstId = await assistantStore.createAssistant(name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: fileIds.isEmpty ? nil : fileIds)
+
+        guard let asstId else {
+            print("failed to create Assistant.")
+            return
+        }
+
+        store.createConversation(type: .assistant, assistantId: asstId)
     }
 }

--- a/Demo/DemoChat/Sources/UI/ChatView.swift
+++ b/Demo/DemoChat/Sources/UI/ChatView.swift
@@ -15,22 +15,6 @@ public struct ChatView: View {
     @Environment(\.dateProviderValue) var dateProvider
     @Environment(\.idProviderValue) var idProvider
 
-
-    @State private var isModalPresented = false
-    @State private var name: String = ""
-    @State private var description: String = ""
-    @State private var customInstructions: String = ""
-
-    @State private var codeInterpreter: Bool = false
-    @State private var retrieval: Bool = false
-    @State private var fileIds: [String] = []
-
-
-    @State private var isPickerPresented: Bool = false
-    @State private var fileURL: URL?
-    @State private var uploadedFileId: String?
-
-
     public init(store: ChatStore, assistantStore: AssistantStore) {
         self.store = store
         self.assistantStore = assistantStore
@@ -52,15 +36,9 @@ public struct ChatView: View {
                     ToolbarItem(
                         placement: .primaryAction
                     ) {
-
                         Menu {
                             Button("Create Chat") {
                                 store.createConversation()
-
-                            }
-                            Button("Create Assistant") {
-                                isModalPresented = true
-
                             }
                         } label: {
                             Image(systemName: "plus")
@@ -90,49 +68,6 @@ public struct ChatView: View {
                     )
                 }
             }
-            .sheet(isPresented: $isModalPresented) {
-                AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
-                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds, modify: false, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
-                    Task {
-                        await handleOKTap()
-                    }
-                } onFileUpload: {
-                    Task {
-                        guard let fileURL else { return }
-
-                        uploadedFileId = await assistantStore.uploadFile(url: fileURL)
-                        if uploadedFileId == nil {
-                            print("Failed to upload")
-                        }
-                    }
-                }
-            }
         }
-    }
-    func handleOKTap() async {
-        
-        var fileIds = [String]()
-        if let fileId = uploadedFileId {
-            fileIds.append(fileId)
-        }
-
-        let asstId = await assistantStore.createAssistant(name: name, description: description, instructions: customInstructions, codeInterpreter: codeInterpreter, retrievel: retrieval, fileIds: fileIds.isEmpty ? nil : fileIds)
-
-        guard let asstId else {
-            print("failed to create Assistant.")
-            return
-        }
-
-        // Reset state for Assistant creator.
-        name = ""
-        description = ""
-        customInstructions = ""
-
-        codeInterpreter = false
-        retrieval = false
-        fileURL = nil
-        uploadedFileId = nil
-
-        store.createConversation(type: .assistant, assistantId: asstId)
     }
 }

--- a/Demo/DemoChat/Sources/UI/ChatView.swift
+++ b/Demo/DemoChat/Sources/UI/ChatView.swift
@@ -23,6 +23,7 @@ public struct ChatView: View {
 
     @State private var codeInterpreter: Bool = false
     @State private var retrieval: Bool = false
+    @State private var fileIds: [String] = []
 
 
     @State private var isPickerPresented: Bool = false
@@ -64,7 +65,6 @@ public struct ChatView: View {
                         } label: {
                             Image(systemName: "plus")
                         }
-
                         .buttonStyle(.borderedProminent)
                     }
                 }
@@ -92,7 +92,7 @@ public struct ChatView: View {
             }
             .sheet(isPresented: $isModalPresented) {
                 AssistantModalContentView(name: $name, description: $description, customInstructions: $customInstructions,
-                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, modify: false, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
+                                          codeInterpreter: $codeInterpreter, retrieval: $retrieval, fileIds: $fileIds, modify: false, isPickerPresented: $isPickerPresented, selectedFileURL: $fileURL) {
                     Task {
                         await handleOKTap()
                     }
@@ -111,16 +111,6 @@ public struct ChatView: View {
     }
     func handleOKTap() async {
         
-        // Reset state for Assistant creator.
-        name = ""
-        description = ""
-        customInstructions = ""
-
-        codeInterpreter = false
-        retrieval = false
-        fileURL = nil
-        uploadedFileId = nil
-        
         var fileIds = [String]()
         if let fileId = uploadedFileId {
             fileIds.append(fileId)
@@ -132,6 +122,16 @@ public struct ChatView: View {
             print("failed to create Assistant.")
             return
         }
+
+        // Reset state for Assistant creator.
+        name = ""
+        description = ""
+        customInstructions = ""
+
+        codeInterpreter = false
+        retrieval = false
+        fileURL = nil
+        uploadedFileId = nil
 
         store.createConversation(type: .assistant, assistantId: asstId)
     }

--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -71,9 +71,8 @@ struct DetailView: View {
                 .navigationTitle(conversation.type == .assistant ? "Assistant: \(currentAssistantName())" : "Chat")
                 .safeAreaInset(edge: .top) {
                     HStack {
-                        // TODO: Replace with actual gpt-4-1106-preview model.
                         Text(
-                            "Model: \(conversation.type == .assistant ? "gpt-4-1106-preview" : selectedChatModel)"
+                            "Model: \(conversation.type == .assistant ? Model.gpt4_1106_preview : selectedChatModel)"
                         )
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -18,12 +18,15 @@ struct DetailView: View {
     @FocusState private var isFocused: Bool
     @State private var showsModelSelectionSheet = false
     @State private var selectedChatModel: Model = .gpt4_0613
+    var availableAssistants: [Assistant]
 
     private let availableChatModels: [Model] = [.gpt3_5Turbo0613, .gpt4_0613]
 
     let conversation: Conversation
     let error: Error?
     let sendMessage: (String, Model) -> Void
+
+    @Binding var isSendingMessage: Bool
 
     private var fillColor: Color {
         #if os(iOS)
@@ -65,11 +68,12 @@ struct DetailView: View {
 
                     inputBar(scrollViewProxy: scrollViewProxy)
                 }
-                .navigationTitle("Chat")
+                .navigationTitle(conversation.type == .assistant ? "Assistant: \(currentAssistantName())" : "Chat")
                 .safeAreaInset(edge: .top) {
                     HStack {
+                        // TODO: Replace with actual gpt-4-1106-preview model.
                         Text(
-                            "Model: \(selectedChatModel)"
+                            "Model: \(conversation.type == .assistant ? "gpt-4-1106-preview" : selectedChatModel)"
                         )
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -79,11 +83,28 @@ struct DetailView: View {
                     .padding(.vertical, 8)
                 }
                 .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button(action: {
-                            showsModelSelectionSheet.toggle()
-                        }) {
-                            Image(systemName: "cpu")
+                    if conversation.type == .assistant {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+
+                            Menu {
+                                ForEach(availableAssistants, id: \.self) { item in
+                                    Button(item.name) {
+                                        print("Select assistant")
+                                        //selectedItem = item
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "eyeglasses")
+                            }
+                        }
+                    }
+                    if conversation.type == .normal {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Button(action: {
+                                showsModelSelectionSheet.toggle()
+                            }) {
+                                Image(systemName: "cpu")
+                            }
                         }
                     }
                 }
@@ -165,18 +186,24 @@ struct DetailView: View {
             }
             .padding(.leading)
 
-            Button(action: {
-                withAnimation {
-                    tapSendMessage(scrollViewProxy: scrollViewProxy)
+            if isSendingMessage {
+                 ProgressView()
+                     .progressViewStyle(CircularProgressViewStyle())
+                     .padding(.trailing)
+            } else {
+                Button(action: {
+                    withAnimation {
+                        tapSendMessage(scrollViewProxy: scrollViewProxy)
+                    }
+                }) {
+                    Image(systemName: "paperplane")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
+                        .padding(.trailing)
                 }
-            }) {
-                Image(systemName: "paperplane")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 24, height: 24)
-                    .padding(.trailing)
+                .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-            .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         }
         .padding(.bottom)
     }
@@ -195,6 +222,10 @@ struct DetailView: View {
 //        if let lastMessage = conversation.messages.last {
 //            scrollViewProxy.scrollTo(lastMessage.id, anchor: .bottom)
 //        }
+    }
+
+    func currentAssistantName() -> String {
+        availableAssistants.filter { conversation.assistantId == $0.id }.first?.name ?? ""
     }
 }
 
@@ -261,6 +292,7 @@ struct ChatBubble: View {
 struct DetailView_Previews: PreviewProvider {
     static var previews: some View {
         DetailView(
+            availableAssistants: [],
             conversation: Conversation(
                 id: "1",
                 messages: [
@@ -277,7 +309,7 @@ struct DetailView_Previews: PreviewProvider {
                 ]
             ),
             error: nil,
-            sendMessage: { _, _ in }
+            sendMessage: { _, _ in }, isSendingMessage: Binding.constant(false)
         )
     }
 }

--- a/Demo/DemoChat/Sources/UI/DetailView.swift
+++ b/Demo/DemoChat/Sources/UI/DetailView.swift
@@ -54,6 +54,10 @@ struct DetailView: View {
                         }
                         .listRowSeparator(.hidden)
                     }
+                    // Tapping on the message bubble area should dismiss the keyboard.
+                    .onTapGesture {
+                        self.hideKeyboard()
+                    }
                     .listStyle(.plain)
                     .animation(.default, value: conversation.messages)
 //                    .onChange(of: conversation) { newValue in
@@ -225,6 +229,9 @@ struct DetailView: View {
 
     func currentAssistantName() -> String {
         availableAssistants.filter { conversation.assistantId == $0.id }.first?.name ?? ""
+    }
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
 

--- a/Demo/DemoChat/Sources/UI/DocumentPicker.swift
+++ b/Demo/DemoChat/Sources/UI/DocumentPicker.swift
@@ -1,0 +1,42 @@
+//
+//  DocumentPicker.swift
+//
+//
+//  Created by Chris Dillard on 11/10/23.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentPicker: UIViewControllerRepresentable {
+    var callback: (URL) -> Void
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        // TODO: Support all the same file types as openAI.
+        let supportedTypes: [UTType] = [UTType.pdf]
+        let pickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: supportedTypes, asCopy: true)
+        pickerViewController.allowsMultipleSelection = false
+        pickerViewController.shouldShowFileExtensions = true
+        pickerViewController.delegate = context.coordinator
+        return pickerViewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIDocumentPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UIDocumentPickerDelegate {
+        var parent: DocumentPicker
+
+        init(_ parent: DocumentPicker) {
+            self.parent = parent
+        }
+
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            parent.callback(url)
+        }
+    }
+}

--- a/Demo/DemoChat/Sources/UI/DocumentPicker.swift
+++ b/Demo/DemoChat/Sources/UI/DocumentPicker.swift
@@ -12,11 +12,10 @@ struct DocumentPicker: UIViewControllerRepresentable {
     var callback: (URL) -> Void
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
-        // TODO: Support all the same file types as openAI.
-        let supportedTypes: [UTType] = [UTType.pdf]
-        let pickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: supportedTypes, asCopy: true)
+        let pickerViewController = UIDocumentPickerViewController(forOpeningContentTypes: supportedUITypes(), asCopy: true)
         pickerViewController.allowsMultipleSelection = false
         pickerViewController.shouldShowFileExtensions = true
+
         pickerViewController.delegate = context.coordinator
         return pickerViewController
     }

--- a/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
@@ -57,12 +57,12 @@ public struct ImageCreationView: View {
             if !$store.images.isEmpty {
                 Section("Images") {
                     ForEach($store.images, id: \.self) { image in
-                        let urlString = image.wrappedValue.url
-                        if let imageURL = URL(string: urlString ?? ""), UIApplication.shared.canOpenURL(imageURL) {
+                        let urlString = image.wrappedValue.url ?? ""
+                        if let imageURL = URL(string: urlString), UIApplication.shared.canOpenURL(imageURL) {
                             LinkPreview(previewURL: imageURL)
                                 .aspectRatio(contentMode: .fit)
                         } else {
-                            Text(urlString ?? "")
+                            Text(urlString)
                                 .foregroundStyle(.secondary)
                         }
                     }

--- a/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
+++ b/Demo/DemoChat/Sources/UI/Images/ImageCreationView.swift
@@ -58,11 +58,11 @@ public struct ImageCreationView: View {
                 Section("Images") {
                     ForEach($store.images, id: \.self) { image in
                         let urlString = image.wrappedValue.url
-                        if let imageURL = URL(string: urlString), UIApplication.shared.canOpenURL(imageURL) {
+                        if let imageURL = URL(string: urlString ?? ""), UIApplication.shared.canOpenURL(imageURL) {
                             LinkPreview(previewURL: imageURL)
                                 .aspectRatio(contentMode: .fit)
                         } else {
-                            Text(urlString)
+                            Text(urlString ?? "")
                                 .foregroundStyle(.secondary)
                         }
                     }

--- a/Demo/DemoChat/Sources/UI/ListView.swift
+++ b/Demo/DemoChat/Sources/UI/ListView.swift
@@ -17,10 +17,28 @@ struct ListView: View {
             editActions: [.delete],
             selection: $selectedConversationId
         ) { $conversation in
-            Text(
-                conversation.messages.last?.content ?? "New Conversation"
-            )
-            .lineLimit(2)
+            if let convoContent = conversation.messages.last?.content {
+                Text(
+                    convoContent
+                )
+                .lineLimit(2)
+            }
+            else {
+                if conversation.type == .assistant {
+                    Text(
+                        "New Assistant"
+                    )
+                    .lineLimit(2)
+                }
+                else {
+                    Text(
+                        "New Conversation"
+                    )
+                    .lineLimit(2)
+                }
+            }
+
+
         }
         .navigationTitle("Conversations")
     }

--- a/Demo/DemoChat/Sources/UI/ModerationChatView.swift
+++ b/Demo/DemoChat/Sources/UI/ModerationChatView.swift
@@ -19,7 +19,7 @@ public struct ModerationChatView: View {
     
     public var body: some View {
         DetailView(
-            conversation: store.moderationConversation,
+            availableAssistants: [], conversation: store.moderationConversation, 
             error: store.moderationConversationError,
             sendMessage: { message, _ in
                 Task {
@@ -32,7 +32,7 @@ public struct ModerationChatView: View {
                         )
                     )
                 }
-            }
+            }, isSendingMessage: Binding.constant(false)
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ This repository contains Swift community-maintained implementation over [OpenAI]
     - [Audio](#audio)
         - [Audio Transcriptions](#audio-transcriptions)
         - [Audio Translations](#audio-translations)
+    - [Assistants](#assistants)
+        - [Create Assistant](#create-assistant)
+        - [Modify Assistant](#modify-assistant)
+        - [List Assistants](#list-assistants) 
+        - [Threads](#threads)
+          - [Create Thread](#create-thread)
+          - [Get Threads Messages](#get-threads-messages)
+          - [Add Message to Thread](#add-message-to-thread)
+        - [Runs](#runs)
+          - [Create Run](#create-run)
+          - [Retrieve Run](#retrieve-run)
+        - [Files](#files)
+          - [Upload File](#upload-file)
     - [Edits](#edits)
     - [Embeddings](#embeddings)
     - [Models](#models)
@@ -514,6 +527,112 @@ let result = try await openAI.imageVariations(query: query)
 ```
 
 Review [Images Documentation](https://platform.openai.com/docs/api-reference/images) for more info.
+
+### Assistants
+
+Review [Assistants Documentation](https://platform.openai.com/docs/api-reference/assistants) for more info.
+
+#### Create Assistant
+
+Example: Create Assistant
+```
+let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+openAI.assistants(query: query) { result in
+   //Handle response here
+}
+```
+
+#### Modify Assistant
+
+Example: Modify Assistant
+```
+let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+openAI.assistantModify(query: query, asstId: "asst_1234") { result in
+    //Handle response here
+}
+```
+
+#### List Assistants
+
+Example: List Assistants
+```
+openAI.assistants(query: nil, method: "GET") { result in
+   //Handle response here
+}
+```
+
+#### Threads
+
+Review [Threads Documentation](https://platform.openai.com/docs/api-reference/threads) for more info.
+
+##### Create Thread
+
+Example: Create Thread
+```
+let threadsQuery = ThreadsQuery(messages: [Chat(role: message.role, content: message.content)])
+openAI.threads(query: threadsQuery) { result in
+  //Handle response here
+}
+```
+
+##### Get Threads Messages
+
+Review [Messages Documentation](https://platform.openai.com/docs/api-reference/messages) for more info.
+
+Example: Get Threads Messages
+```
+openAI.threadsMessages(threadId: currentThreadId, before: nil) { result in
+  //Handle response here
+}
+```
+
+##### Add Message to Thread
+
+Example: Add Message to Thread
+```
+let query = ThreadAddMessageQuery(role: message.role.rawValue, content: message.content)
+openAI.threadsAddMessage(threadId: currentThreadId, query: query) { result in
+  //Handle response here
+}
+```
+
+#### Runs
+
+Review [Runs Documentation](https://platform.openai.com/docs/api-reference/runs) for more info.
+
+##### Create Run
+
+Example: Create Run
+```
+let runsQuery = RunsQuery(assistantId:  currentAssistantId)
+openAI.runs(threadId: threadsResult.id, query: runsQuery) { result in
+  //Handle response here
+}
+```
+
+##### Retrieve Run
+
+Example: Retrieve Run
+```
+openAI.runRetrieve(threadId: currentThreadId, runId: currentRunId) { result in
+  //Handle response here
+}
+```
+
+#### Files
+
+Review [Files Documentation](https://platform.openai.com/docs/api-reference/files) for more info.
+
+##### Upload file
+
+Example: Upload file
+```
+let query = FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: "application/pdf")
+openAI.files(query: query) { result in
+  //Handle response here
+}
+```
+
 
 ### Audio
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ This repository contains Swift community-maintained implementation over [OpenAI]
         - [Audio Create Speech](#audio-create-speech)
         - [Audio Transcriptions](#audio-transcriptions)
         - [Audio Translations](#audio-translations)
-    - [Assistants](#assistants)
+    - [Edits](#edits)
+    - [Embeddings](#embeddings)
+    - [Models](#models)
+        - [List Models](#list-models)
+        - [Retrieve Model](#retrieve-model)
+    - [Moderations](#moderations)
+    - [Utilities](#utilities)
+    - [Combine Extensions](#combine-extensions)
+    - [Assistants (Beta)](#assistants)
         - [Create Assistant](#create-assistant)
         - [Modify Assistant](#modify-assistant)
         - [List Assistants](#list-assistants) 
@@ -38,16 +46,10 @@ This repository contains Swift community-maintained implementation over [OpenAI]
         - [Runs](#runs)
           - [Create Run](#create-run)
           - [Retrieve Run](#retrieve-run)
+          - [Retrieve Run Steps](#retrieve-run-steps)
+
         - [Files](#files)
           - [Upload File](#upload-file)
-    - [Edits](#edits)
-    - [Embeddings](#embeddings)
-    - [Models](#models)
-        - [List Models](#list-models)
-        - [Retrieve Model](#retrieve-model)
-    - [Moderations](#moderations)
-    - [Utilities](#utilities)
-    - [Combine Extensions](#combine-extensions)
 - [Example Project](#example-project)
 - [Contribution Guidelines](#contribution-guidelines)
 - [Links](#links)
@@ -529,112 +531,6 @@ let result = try await openAI.imageVariations(query: query)
 
 Review [Images Documentation](https://platform.openai.com/docs/api-reference/images) for more info.
 
-### Assistants
-
-Review [Assistants Documentation](https://platform.openai.com/docs/api-reference/assistants) for more info.
-
-#### Create Assistant
-
-Example: Create Assistant
-```
-let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
-openAI.assistants(query: query) { result in
-   //Handle response here
-}
-```
-
-#### Modify Assistant
-
-Example: Modify Assistant
-```
-let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
-openAI.assistantModify(query: query, asstId: "asst_1234") { result in
-    //Handle response here
-}
-```
-
-#### List Assistants
-
-Example: List Assistants
-```
-openAI.assistants(query: nil, method: "GET") { result in
-   //Handle response here
-}
-```
-
-#### Threads
-
-Review [Threads Documentation](https://platform.openai.com/docs/api-reference/threads) for more info.
-
-##### Create Thread
-
-Example: Create Thread
-```
-let threadsQuery = ThreadsQuery(messages: [Chat(role: message.role, content: message.content)])
-openAI.threads(query: threadsQuery) { result in
-  //Handle response here
-}
-```
-
-##### Get Threads Messages
-
-Review [Messages Documentation](https://platform.openai.com/docs/api-reference/messages) for more info.
-
-Example: Get Threads Messages
-```
-openAI.threadsMessages(threadId: currentThreadId, before: nil) { result in
-  //Handle response here
-}
-```
-
-##### Add Message to Thread
-
-Example: Add Message to Thread
-```
-let query = ThreadAddMessageQuery(role: message.role.rawValue, content: message.content)
-openAI.threadsAddMessage(threadId: currentThreadId, query: query) { result in
-  //Handle response here
-}
-```
-
-#### Runs
-
-Review [Runs Documentation](https://platform.openai.com/docs/api-reference/runs) for more info.
-
-##### Create Run
-
-Example: Create Run
-```
-let runsQuery = RunsQuery(assistantId:  currentAssistantId)
-openAI.runs(threadId: threadsResult.id, query: runsQuery) { result in
-  //Handle response here
-}
-```
-
-##### Retrieve Run
-
-Example: Retrieve Run
-```
-openAI.runRetrieve(threadId: currentThreadId, runId: currentRunId) { result in
-  //Handle response here
-}
-```
-
-#### Files
-
-Review [Files Documentation](https://platform.openai.com/docs/api-reference/files) for more info.
-
-##### Upload file
-
-Example: Upload file
-```
-let query = FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: "application/pdf")
-openAI.files(query: query) { result in
-  //Handle response here
-}
-```
-
-
 ### Audio
 
 The speech to text API provides two endpoints, transcriptions and translations, based on our state-of-the-art open source large-v2 [Whisper model](https://openai.com/research/whisper). They can be used to:
@@ -1115,6 +1011,120 @@ func models() -> AnyPublisher<ModelsResult, Error>
 func moderations(query: ModerationsQuery) -> AnyPublisher<ModerationsResult, Error>
 func audioTranscriptions(query: AudioTranscriptionQuery) -> AnyPublisher<AudioTranscriptionResult, Error>
 func audioTranslations(query: AudioTranslationQuery) -> AnyPublisher<AudioTranslationResult, Error>
+```
+
+### Assistants
+
+Review [Assistants Documentation](https://platform.openai.com/docs/api-reference/assistants) for more info.
+
+#### Create Assistant
+
+Example: Create Assistant
+```
+let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+openAI.assistants(query: query) { result in
+   //Handle response here
+}
+```
+
+#### Modify Assistant
+
+Example: Modify Assistant
+```
+let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+openAI.assistantModify(query: query, asstId: "asst_1234") { result in
+    //Handle response here
+}
+```
+
+#### List Assistants
+
+Example: List Assistants
+```
+openAI.assistants(query: nil, method: "GET") { result in
+   //Handle response here
+}
+```
+
+#### Threads
+
+Review [Threads Documentation](https://platform.openai.com/docs/api-reference/threads) for more info.
+
+##### Create Thread
+
+Example: Create Thread
+```
+let threadsQuery = ThreadsQuery(messages: [Chat(role: message.role, content: message.content)])
+openAI.threads(query: threadsQuery) { result in
+  //Handle response here
+}
+```
+
+##### Get Threads Messages
+
+Review [Messages Documentation](https://platform.openai.com/docs/api-reference/messages) for more info.
+
+Example: Get Threads Messages
+```
+openAI.threadsMessages(threadId: currentThreadId, before: nil) { result in
+  //Handle response here
+}
+```
+
+##### Add Message to Thread
+
+Example: Add Message to Thread
+```
+let query = ThreadAddMessageQuery(role: message.role.rawValue, content: message.content)
+openAI.threadsAddMessage(threadId: currentThreadId, query: query) { result in
+  //Handle response here
+}
+```
+
+#### Runs
+
+Review [Runs Documentation](https://platform.openai.com/docs/api-reference/runs) for more info.
+
+##### Create Run
+
+Example: Create Run
+```
+let runsQuery = RunsQuery(assistantId:  currentAssistantId)
+openAI.runs(threadId: threadsResult.id, query: runsQuery) { result in
+  //Handle response here
+}
+```
+
+##### Retrieve Run
+
+Example: Retrieve Run
+```
+openAI.runRetrieve(threadId: currentThreadId, runId: currentRunId) { result in
+  //Handle response here
+}
+```
+
+##### Retrieve Run Steps
+
+Example: Retrieve Run Steps
+```
+openAI.runRetrieveSteps(threadId: currentThreadId, runId: currentRunId, before: nil) { result in
+  //Handle response here
+}
+```
+
+#### Files
+
+Review [Files Documentation](https://platform.openai.com/docs/api-reference/files) for more info.
+
+##### Upload file
+
+Example: Upload file
+```
+let query = FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: "application/pdf")
+openAI.files(query: query) { result in
+  //Handle response here
+}
 ```
 
 ## Example Project

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -177,7 +177,7 @@ extension OpenAI {
                 do {
 
                     let errorText = String(data: data, encoding: .utf8)
-                    
+
                     let decoded = try JSONDecoder().decode(ResultType.self, from: data)
                     completion(.success(decoded))
                 } catch {

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -66,11 +66,11 @@ final public class OpenAI: OpenAIProtocol {
     }
 
     public func runRetrieve(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<RunRetreiveResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieve, threadId: threadId, runId: runId), method: "GET"), completion: completion)
+        performRequest(request: JSONRequest<RunRetreiveResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieve, threadId: threadId, runId: runId, before: nil), method: "GET"), completion: completion)
     }
 
-    public func runRetrieveSteps(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void) {
-        performRequest(request: JSONRequest<RunRetreiveStepsResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieveSteps, threadId: threadId, runId: runId), method: "GET"), completion: completion)
+    public func runRetrieveSteps(threadId: String, runId: String, before: String?, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<RunRetreiveStepsResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieveSteps, threadId: threadId, runId: runId, before: before), method: "GET"), completion: completion)
     }
 
     public func runs(threadId: String, query: RunsQuery, completion: @escaping (Result<RunsResult, Error>) -> Void) {
@@ -178,8 +178,6 @@ extension OpenAI {
 
                     let errorText = String(data: data, encoding: .utf8)
                     
-                    // print(errorText)
-                    
                     let decoded = try JSONDecoder().decode(ResultType.self, from: data)
                     completion(.success(decoded))
                 } catch {
@@ -284,12 +282,15 @@ extension OpenAI {
         return components.url!
     }
 
-    func buildRunRetrieveURL(path: String, threadId: String, runId: String) -> URL {
+    func buildRunRetrieveURL(path: String, threadId: String, runId: String, before: String? = nil) -> URL {
         var components = URLComponents()
         components.scheme = "https"
         components.host = configuration.host
         components.path = path.replacingOccurrences(of: "THREAD_ID", with: threadId)
                               .replacingOccurrences(of: "RUN_ID", with: runId)
+        if let before {
+            components.queryItems = [URLQueryItem(name: "before", value: before)]
+        }
         return components.url!
     }
 
@@ -312,10 +313,8 @@ extension APIPath {
     static let runs = "/v1/threads/THREAD_ID/runs"
     static let runRetrieve = "/v1/threads/THREAD_ID/runs/RUN_ID"
     static let runRetrieveSteps = "/v1/threads/THREAD_ID/runs/RUN_ID/steps"
-
     static let threadsMessages = "/v1/threads/THREAD_ID/messages"
     static let files = "/v1/files"
-    
     // 1106 end
 
     static let completions = "/v1/completions"

--- a/Sources/OpenAI/OpenAI.swift
+++ b/Sources/OpenAI/OpenAI.swift
@@ -69,6 +69,10 @@ final public class OpenAI: OpenAIProtocol {
         performRequest(request: JSONRequest<RunRetreiveResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieve, threadId: threadId, runId: runId), method: "GET"), completion: completion)
     }
 
+    public func runRetrieveSteps(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void) {
+        performRequest(request: JSONRequest<RunRetreiveStepsResult>(body: nil, url: buildRunRetrieveURL(path: .runRetrieveSteps, threadId: threadId, runId: runId), method: "GET"), completion: completion)
+    }
+
     public func runs(threadId: String, query: RunsQuery, completion: @escaping (Result<RunsResult, Error>) -> Void) {
         performRequest(request: JSONRequest<RunsResult>(body: query, url: buildRunsURL(path: .runs, threadId: threadId)), completion: completion)
     }
@@ -173,7 +177,9 @@ extension OpenAI {
                 do {
 
                     let errorText = String(data: data, encoding: .utf8)
-
+                    
+                    // print(errorText)
+                    
                     let decoded = try JSONDecoder().decode(ResultType.self, from: data)
                     completion(.success(decoded))
                 } catch {
@@ -305,8 +311,11 @@ extension APIPath {
     static let threads = "/v1/threads"
     static let runs = "/v1/threads/THREAD_ID/runs"
     static let runRetrieve = "/v1/threads/THREAD_ID/runs/RUN_ID"
+    static let runRetrieveSteps = "/v1/threads/THREAD_ID/runs/RUN_ID/steps"
+
     static let threadsMessages = "/v1/threads/THREAD_ID/messages"
     static let files = "/v1/files"
+    
     // 1106 end
 
     static let completions = "/v1/completions"

--- a/Sources/OpenAI/Private/JSONRequest.swift
+++ b/Sources/OpenAI/Private/JSONRequest.swift
@@ -29,6 +29,9 @@ extension JSONRequest: URLRequestBuildable {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        // TODO: ONLY PASS IF ASSISTANTS API
+        request.setValue("assistants=v1", forHTTPHeaderField: "OpenAI-Beta")
+
         if let organizationIdentifier {
             request.setValue(organizationIdentifier, forHTTPHeaderField: "OpenAI-Organization")
         }

--- a/Sources/OpenAI/Public/Models/AssistantsQuery.swift
+++ b/Sources/OpenAI/Public/Models/AssistantsQuery.swift
@@ -1,0 +1,56 @@
+//
+//  AssistantsQuery.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct AssistantsQuery: Codable {
+
+    public let model: Model
+
+    public let name: String
+
+    public let description: String
+
+    public let instructions: String
+
+    public let tools: [Tool]?
+
+    public let fileIds: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case name
+        case description
+        case instructions
+        case tools
+        case fileIds = "file_ids"
+    }
+    
+    public init(model: Model, name: String, description: String, instructions: String, tools: [Tool], fileIds: [String]? = nil) {
+        self.model = model
+        self.name = name
+
+        self.description = description
+        self.instructions = instructions
+
+        self.tools = tools
+        self.fileIds = fileIds
+    }
+}
+
+public struct Tool: Codable, Equatable {
+    public let toolType: String
+
+    enum CodingKeys: String, CodingKey {
+        case toolType = "type"
+    }
+
+    public init(toolType: String) {
+        self.toolType = toolType
+    }
+
+}

--- a/Sources/OpenAI/Public/Models/AssistantsResult.swift
+++ b/Sources/OpenAI/Public/Models/AssistantsResult.swift
@@ -1,0 +1,30 @@
+//
+//  AssistantsResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct AssistantsResult: Codable, Equatable {
+
+    public let id: String?
+
+    public let data: [AssistantContent]?
+    public let tools: [Tool]?
+
+    enum CodingKeys: String, CodingKey {
+        case data
+        case id
+        case tools
+    }
+
+    public struct AssistantContent: Codable, Equatable {
+
+        public let id: String
+        public let name: String
+        public let description: String?
+        public let instructions: String?
+    }
+}

--- a/Sources/OpenAI/Public/Models/AssistantsResult.swift
+++ b/Sources/OpenAI/Public/Models/AssistantsResult.swift
@@ -26,5 +26,16 @@ public struct AssistantsResult: Codable, Equatable {
         public let name: String
         public let description: String?
         public let instructions: String?
+        public let tools: [Tool]?
+        public let fileIds: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case description
+            case instructions
+            case tools
+            case fileIds = "file_ids"
+        }
     }
 }

--- a/Sources/OpenAI/Public/Models/FilesQuery.swift
+++ b/Sources/OpenAI/Public/Models/FilesQuery.swift
@@ -1,0 +1,42 @@
+//
+//  AssistantsQuery.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct FilesQuery: Codable {
+
+    public let purpose: String
+
+    public let file: Data
+    public let fileName: String
+
+    public let contentType: String
+
+    enum CodingKeys: String, CodingKey {
+        case purpose
+        case file
+        case fileName
+        case contentType
+    }
+    
+    public init(purpose: String, file: Data, fileName: String, contentType: String) {
+        self.purpose = purpose
+        self.file = file
+        self.fileName = fileName
+        self.contentType = contentType
+    }
+}
+
+extension FilesQuery: MultipartFormDataBodyEncodable {
+    func encode(boundary: String) -> Data {
+        let bodyBuilder = MultipartFormDataBodyBuilder(boundary: boundary, entries: [
+            .string(paramName: "purpose", value: purpose),
+            .file(paramName: "file", fileName: fileName, fileData: file, contentType: contentType),
+        ])
+        return bodyBuilder.build()
+    }
+}

--- a/Sources/OpenAI/Public/Models/FilesQuery.swift
+++ b/Sources/OpenAI/Public/Models/FilesQuery.swift
@@ -1,5 +1,5 @@
 //
-//  AssistantsQuery.swift
+//  FilesQuery.swift
 //  
 //
 //  Created by Chris Dillard on 11/07/2023.

--- a/Sources/OpenAI/Public/Models/FilesResult.swift
+++ b/Sources/OpenAI/Public/Models/FilesResult.swift
@@ -1,0 +1,14 @@
+//
+//  FilesResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct FilesResult: Codable, Equatable {
+
+    public let id: String
+
+}

--- a/Sources/OpenAI/Public/Models/FilesResult.swift
+++ b/Sources/OpenAI/Public/Models/FilesResult.swift
@@ -10,5 +10,6 @@ import Foundation
 public struct FilesResult: Codable, Equatable {
 
     public let id: String
+    public let name: String
 
 }

--- a/Sources/OpenAI/Public/Models/RunRetrieveQuery.swift
+++ b/Sources/OpenAI/Public/Models/RunRetrieveQuery.swift
@@ -1,0 +1,15 @@
+//
+//  RunRetrieveQuery.swift
+//
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct RunRetrieveQuery: Equatable, Codable {
+
+    public init() {
+
+    }
+}

--- a/Sources/OpenAI/Public/Models/RunRetrieveResult.swift
+++ b/Sources/OpenAI/Public/Models/RunRetrieveResult.swift
@@ -1,0 +1,13 @@
+//
+//  RunsResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct RunRetreiveResult: Codable, Equatable {
+
+    public let status: String
+}

--- a/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
+++ b/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
@@ -1,0 +1,42 @@
+//
+//  RunRetreiveStepsResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct RunRetreiveStepsResult: Codable, Equatable {
+    
+    public struct StepDetailsTopLevel: Codable, Equatable {
+
+        public let stepDetails: StepDetailsSecondLevel
+
+        enum CodingKeys: String, CodingKey {
+            case stepDetails = "step_details"
+        }
+
+        public struct StepDetailsSecondLevel: Codable, Equatable {
+
+            public let toolCalls: [ToolCall]?
+
+            enum CodingKeys: String, CodingKey {
+                case toolCalls = "tool_calls"
+            }
+
+            public struct ToolCall: Codable, Equatable {
+                public let type: String
+                public let code: CodeToolCall?
+                
+                public struct CodeToolCall: Codable, Equatable {
+                    public let input: String
+                    public let outputs: [[String: String]]
+
+                }
+            }
+        }
+    }
+
+    public let data: [StepDetailsTopLevel]
+}

--- a/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
+++ b/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
@@ -27,13 +27,25 @@ public struct RunRetreiveStepsResult: Codable, Equatable {
             }
 
             public struct ToolCall: Codable, Equatable {
+                public let id: String
                 public let type: String
                 public let code: CodeToolCall?
                 
+                enum CodingKeys: String, CodingKey {
+                    case id
+                    case type
+                    case code = "code_interpreter"
+                }
+
                 public struct CodeToolCall: Codable, Equatable {
                     public let input: String
-                    public let outputs: [[String: String]]
+                    public let outputs: [CodeToolCallOutput]?
 
+                    public struct CodeToolCallOutput: Codable, Equatable {
+                        public let type: String
+                        public let logs: String?
+
+                    }
                 }
             }
         }

--- a/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
+++ b/Sources/OpenAI/Public/Models/RunRetrieveStepsResult.swift
@@ -10,10 +10,11 @@ import Foundation
 public struct RunRetreiveStepsResult: Codable, Equatable {
     
     public struct StepDetailsTopLevel: Codable, Equatable {
-
+        public let id: String
         public let stepDetails: StepDetailsSecondLevel
 
         enum CodingKeys: String, CodingKey {
+            case id
             case stepDetails = "step_details"
         }
 

--- a/Sources/OpenAI/Public/Models/RunsQuery.swift
+++ b/Sources/OpenAI/Public/Models/RunsQuery.swift
@@ -1,0 +1,22 @@
+//
+//  AssistantsQuery.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct RunsQuery: Codable {
+
+    public let assistantId: String
+
+    enum CodingKeys: String, CodingKey {
+        case assistantId = "assistant_id"
+    }
+    
+    public init(assistantId: String) {
+
+        self.assistantId = assistantId
+    }
+}

--- a/Sources/OpenAI/Public/Models/RunsResult.swift
+++ b/Sources/OpenAI/Public/Models/RunsResult.swift
@@ -1,0 +1,13 @@
+//
+//  RunsResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct RunsResult: Codable, Equatable {
+
+    public let id: String
+}

--- a/Sources/OpenAI/Public/Models/ThreadAddMessageQuery.swift
+++ b/Sources/OpenAI/Public/Models/ThreadAddMessageQuery.swift
@@ -1,0 +1,24 @@
+//
+//  ThreadAddMessageQuery.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct ThreadAddMessageQuery: Equatable, Codable {
+    public let role: String
+    public let content: String
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case content
+
+    }
+    
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}

--- a/Sources/OpenAI/Public/Models/ThreadAddMessagesResult.swift
+++ b/Sources/OpenAI/Public/Models/ThreadAddMessagesResult.swift
@@ -1,0 +1,13 @@
+//
+//  ThreadsMessagesResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct ThreadAddMessageResult: Codable, Equatable {
+    public let id: String
+
+}

--- a/Sources/OpenAI/Public/Models/ThreadsMessagesResult.swift
+++ b/Sources/OpenAI/Public/Models/ThreadsMessagesResult.swift
@@ -1,0 +1,53 @@
+//
+//  ThreadsMessagesResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct ThreadsMessagesResult: Codable, Equatable {
+
+    public struct ThreadsMessage: Codable, Equatable {
+
+        public struct ThreadsMessageContent: Codable, Equatable {
+
+            public struct ThreadsMessageContentText: Codable, Equatable {
+
+                public let value: String
+                
+                enum CodingKeys: String, CodingKey {
+                    case value
+                }
+            }
+
+            public let type: String
+            public let text: ThreadsMessageContentText
+
+            enum CodingKeys: String, CodingKey {
+                case type
+                case text
+            }
+        }
+        public let id: String
+
+        public let role: String
+
+        public let content: [ThreadsMessageContent]
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case content
+            case role
+        }
+    }
+
+
+    public let data: [ThreadsMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case data
+    }
+
+}

--- a/Sources/OpenAI/Public/Models/ThreadsMessagesResult.swift
+++ b/Sources/OpenAI/Public/Models/ThreadsMessagesResult.swift
@@ -15,21 +15,33 @@ public struct ThreadsMessagesResult: Codable, Equatable {
 
             public struct ThreadsMessageContentText: Codable, Equatable {
 
-                public let value: String
-                
+                public let value: String?
+
                 enum CodingKeys: String, CodingKey {
                     case value
                 }
             }
 
+            public struct ImageFileContentText: Codable, Equatable {
+
+                public let fildId: String
+
+                enum CodingKeys: String, CodingKey {
+                    case fildId = "file_id"
+                }
+            }
+
             public let type: String
-            public let text: ThreadsMessageContentText
+            public let text: ThreadsMessageContentText?
+            public let imageFile: ThreadsMessageContentText?
 
             enum CodingKeys: String, CodingKey {
                 case type
                 case text
+                case imageFile = "image_file"
             }
         }
+
         public let id: String
 
         public let role: String

--- a/Sources/OpenAI/Public/Models/ThreadsQuery.swift
+++ b/Sources/OpenAI/Public/Models/ThreadsQuery.swift
@@ -1,0 +1,20 @@
+//
+//  ThreadsQuery.swift
+//
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct ThreadsQuery: Equatable, Codable {
+    public let messages: [Chat]
+
+    enum CodingKeys: String, CodingKey {
+        case messages
+    }
+
+    public init(messages: [Chat]) {
+        self.messages = messages
+    }
+}

--- a/Sources/OpenAI/Public/Models/ThreadsResult.swift
+++ b/Sources/OpenAI/Public/Models/ThreadsResult.swift
@@ -1,0 +1,13 @@
+//
+//  AssistantsResult.swift
+//  
+//
+//  Created by Chris Dillard on 11/07/2023.
+//
+
+import Foundation
+
+public struct ThreadsResult: Codable, Equatable {
+
+    public let id: String
+}

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -217,10 +217,27 @@ public extension OpenAIProtocol {
     // 1106
     func assistants(
         query: AssistantsQuery?,
-        method: String
+        method: String,
+        after: String?
     ) async throws -> AssistantsResult {
         try await withCheckedThrowingContinuation { continuation in
-            assistants(query: query, method: method) { result in
+            assistants(query: query, method: method, after: after) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func assistantModify(
+        query: AssistantsQuery,
+        asstId: String
+    ) async throws -> AssistantsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            assistantModify(query: query, asstId: asstId) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -312,10 +312,11 @@ public extension OpenAIProtocol {
 
     func runRetrieveSteps(
         threadId: String,
-        runId: String
+        runId: String,
+        before: String?
     ) async throws -> RunRetreiveStepsResult {
         try await withCheckedThrowingContinuation { continuation in
-            runRetrieveSteps(threadId: threadId, runId: runId) { result in
+            runRetrieveSteps(threadId: threadId, runId: runId, before: before) { result in
                 switch result {
                 case let .success(success):
                     return continuation.resume(returning: success)

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -310,6 +310,22 @@ public extension OpenAIProtocol {
         }
     }
 
+    func runRetrieveSteps(
+        threadId: String,
+        runId: String
+    ) async throws -> RunRetreiveStepsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            runRetrieveSteps(threadId: threadId, runId: runId) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
     func threadsMessages(
         threadId: String,
         before: String?

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Async.swift
@@ -213,4 +213,115 @@ public extension OpenAIProtocol {
             }
         }
     }
+
+    // 1106
+    func assistants(
+        query: AssistantsQuery?,
+        method: String
+    ) async throws -> AssistantsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            assistants(query: query, method: method) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func threads(
+        query: ThreadsQuery
+    ) async throws -> ThreadsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            threads(query: query) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func runs(
+        threadId: String,
+        query: RunsQuery
+    ) async throws -> RunsResult {
+        try await withCheckedThrowingContinuation { continuation in
+            runs(threadId: threadId, query: query) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func runRetrieve(
+        threadId: String,
+        runId: String
+    ) async throws -> RunRetreiveResult {
+        try await withCheckedThrowingContinuation { continuation in
+            runRetrieve(threadId: threadId, runId: runId) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func threadsMessages(
+        threadId: String,
+        before: String?
+    ) async throws -> ThreadsMessagesResult {
+        try await withCheckedThrowingContinuation { continuation in
+            threadsMessages(threadId: threadId, before: before) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+
+    func threadsAddMessage(
+        threadId: String,
+        query: ThreadAddMessageQuery
+    ) async throws -> ThreadAddMessageResult {
+        try await withCheckedThrowingContinuation { continuation in
+            threadsAddMessage(threadId: threadId, query: query) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+    func files(
+        query: FilesQuery
+    ) async throws -> FilesResult {
+        try await withCheckedThrowingContinuation { continuation in
+            files(query: query) { result in
+                switch result {
+                case let .success(success):
+                    return continuation.resume(returning: success)
+                case let .failure(failure):
+                    return continuation.resume(throwing: failure)
+                }
+            }
+        }
+    }
+    // 1106 end
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -128,9 +128,9 @@ public extension OpenAIProtocol {
     }
 
     // 1106
-    func assistants(query: AssistantsQuery?, method: String) -> AnyPublisher<AssistantsResult, Error> {
+    func assistants(query: AssistantsQuery?, method: String, after: String?) -> AnyPublisher<AssistantsResult, Error> {
         Future<AssistantsResult, Error> {
-            assistants(query: query, method: method, completion: $0)
+            assistants(query: query, method: method, after: after, completion: $0)
         }
         .eraseToAnyPublisher()
     }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol+Combine.swift
@@ -126,6 +126,44 @@ public extension OpenAIProtocol {
         }
         .eraseToAnyPublisher()
     }
+
+    // 1106
+    func assistants(query: AssistantsQuery?, method: String) -> AnyPublisher<AssistantsResult, Error> {
+        Future<AssistantsResult, Error> {
+            assistants(query: query, method: method, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func threads(query: ThreadsQuery) -> AnyPublisher<ThreadsResult, Error> {
+        Future<ThreadsResult, Error> {
+            threads(query: query, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func runs(threadId: String, query: RunsQuery) -> AnyPublisher<RunsResult, Error> {
+        Future<RunsResult, Error> {
+            runs(threadId: threadId, query: query, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func runRetrieve(threadId: String, runId: String) -> AnyPublisher<RunRetreiveResult, Error> {
+        Future<RunRetreiveResult, Error> {
+
+            runRetrieve(threadId: threadId, runId: runId, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func threadsMessages(threadId: String, before: String?) -> AnyPublisher<ThreadsMessagesResult, Error> {
+        Future<ThreadsMessagesResult, Error> {
+            threadsMessages(threadId: threadId, before: before, completion: $0)
+        }
+        .eraseToAnyPublisher()
+    }
+    // 1106 end
 }
 
 #endif

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -231,28 +231,138 @@ public protocol OpenAIProtocol {
      **/
     func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void)
     
-    //1106
+    ///
+    // The following functions represent new functionality added to OpenAI Beta on 11-06-23
+    ///
+    ///
+    /**
+     This function sends a assistants query to the OpenAI API and creates an assistant. The Assistants API in this usage enables you to create an assistant.
 
-    // TODO: Assistant Docs
-    func assistants(query: AssistantsQuery?, method: String, completion: @escaping (Result<AssistantsResult, Error>) -> Void)
-    
-    // TODO: Threads Docs
+     Example: Create Assistant
+     ```
+     let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+     openAI.assistants(query: query) { result in
+        //Handle response here
+     }
+     ```
+
+     Example: List Assistants
+     ```
+     openAI.assistants(query: nil, method: "GET") { result in
+        //Handle response here
+     }
+     ```
+
+     - Parameter query: The `AssistantsQuery?` instance, containing the information required for the assistant request. Passing nil is used for GET form of request.
+     - Parameter method: The method to use with the HTTP request. Supports POST (default) and GET.
+     - Parameter completion: The completion handler to be executed upon completion of the assistant request.
+                          Returns a `Result` of type `AssistantsResult` if successful, or an `Error` if an error occurs.
+     **/
+    func assistants(query: AssistantsQuery?, method: String, after: String?, completion: @escaping (Result<AssistantsResult, Error>) -> Void)
+
+    /**
+    This function sends a assistants query to the OpenAI API and modifies an assistant. The Assistants API in this usage enables you to modify an assistant.
+
+    Example: Create Assistant
+    ```
+    let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
+    openAI.assistantModify(query: query, asstId: "asst_1234") { result in
+       //Handle response here
+    }
+    ```
+
+     - Parameter query: The `AssistantsQuery` instance, containing the information required for the assistant request.
+     - Parameter asstId: The assistant id for the assistant to modify.
+     - Parameter completion: The completion handler to be executed upon completion of the assistant request.
+                          Returns a `Result` of type `AssistantsResult` if successful, or an `Error` if an error occurs.
+     **/
+    func assistantModify(query: AssistantsQuery, asstId: String, completion: @escaping (Result<AssistantsResult, Error>) -> Void)
+
+    /**
+     This function sends a threads query to the OpenAI API and creates a thread. The Threads API in this usage enables you to create a thread.
+
+     ```
+     let threadsQuery = ThreadsQuery(messages: [Chat(role: message.role, content: message.content)])
+     openAI.threads(query: threadsQuery) { result in
+        //Handle response here
+     }
+
+     ```
+     - Parameter query: The `ThreadsQuery` instance, containing the information required for the threads request.
+     - Parameter completion: The completion handler to be executed upon completion of the threads request.
+                          Returns a `Result` of type `ThreadsResult` if successful, or an `Error` if an error occurs.
+     **/
     func threads(query: ThreadsQuery, completion: @escaping (Result<ThreadsResult, Error>) -> Void)
 
-    // TODO: Runs Docs
+    /**
+     This function sends a runs query to the OpenAI API and creates a run. The Runs API in this usage enables you to create a run.
+
+     ```
+     let runsQuery = RunsQuery(assistantId:  currentAssistantId)
+     openAI.runs(threadId: threadsResult.id, query: runsQuery) { result in
+        //Handle response here
+     }
+     ```
+     
+     - Parameter threadId: The thread id for the thread to run.
+     - Parameter query: The `RunsQuery` instance, containing the information required for the runs request.
+     - Parameter completion: The completion handler to be executed upon completion of the runs request.
+                          Returns a `Result` of type `RunsResult` if successful, or an `Error` if an error occurs.
+     **/
     func runs(threadId: String, query: RunsQuery, completion: @escaping (Result<RunsResult, Error>) -> Void)
 
-    // TODO: Runs Retrieve Docs
+    /**
+     This function sends a thread id and run id to the OpenAI API and retrieves a run. The Runs API in this usage enables you to retrieve a run.
+
+     ```
+     openAI.runRetrieve(threadId: currentThreadId, runId: currentRunId) { result in
+        //Handle response here
+     }
+     ```
+     - Parameter threadId: The thread id for the thread to run.
+     - Parameter runId: The run id for the run to retrieve.
+     - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
+                          Returns a `Result` of type `RunRetreiveResult` if successful, or an `Error` if an error occurs.
+     **/
     func runRetrieve(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void)
 
-    // TODO: Threads Messages Docs
+    /**
+     This function sends a thread id and run id to the OpenAI API and retrieves a threads messages.
+     The Thread API in this usage enables you to retrieve a threads messages.
+
+
+     ```
+     openAI.threadsMessages(threadId: currentThreadId, before: nil) { result in
+        //Handle response here
+     }
+     ```
+
+     - Parameter threadId: The thread id for the thread to run.
+     - Parameter before: String?: The message id for the message taht defines your place in the list of messages. Pass nil to get all.
+     - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
+                          Returns a `Result` of type `ThreadsMessagesResult` if successful, or an `Error` if an error occurs.
+     **/
     func threadsMessages(threadId: String, before: String?, completion: @escaping (Result<ThreadsMessagesResult, Error>) -> Void)
 
-    // TODO: Threads Add Message Docs
+    /**
+     This function sends a thread id and message contents to the OpenAI API and returns a run.
+
+     ```
+     let query = ThreadAddMessageQuery(role: message.role.rawValue, content: message.content)
+     openAI.threadsAddMessage(threadId: currentThreadId, query: query) { result in
+        //Handle response here
+     }
+     ```
+
+     - Parameter threadId: The thread id for the thread to run.
+     - Parameter query: The `ThreadAddMessageQuery` instance, containing the information required for the threads request.
+     - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
+                          Returns a `Result` of type `ThreadAddMessageResult` if successful, or an `Error` if an error occurs.
+     **/
     func threadsAddMessage(threadId: String, query: ThreadAddMessageQuery, completion: @escaping (Result<ThreadAddMessageResult, Error>) -> Void)
 
     // TODO: Files Docs
     func files(query: FilesQuery, completion: @escaping (Result<FilesResult, Error>) -> Void)
 
-    // 1106 end
+    // END new functionality added to OpenAI Beta on 11-06-23 end
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -263,7 +263,7 @@ public protocol OpenAIProtocol {
     /**
     This function sends a assistants query to the OpenAI API and modifies an assistant. The Assistants API in this usage enables you to modify an assistant.
 
-    Example: Create Assistant
+    Example: Modify Assistant
     ```
     let query = AssistantsQuery(model: Model.gpt4_1106_preview, name: name, description: description, instructions: instructions, tools: tools, fileIds: fileIds)
     openAI.assistantModify(query: query, asstId: "asst_1234") { result in
@@ -281,6 +281,7 @@ public protocol OpenAIProtocol {
     /**
      This function sends a threads query to the OpenAI API and creates a thread. The Threads API in this usage enables you to create a thread.
 
+     Example: Create Thread
      ```
      let threadsQuery = ThreadsQuery(messages: [Chat(role: message.role, content: message.content)])
      openAI.threads(query: threadsQuery) { result in
@@ -297,6 +298,7 @@ public protocol OpenAIProtocol {
     /**
      This function sends a runs query to the OpenAI API and creates a run. The Runs API in this usage enables you to create a run.
 
+     Example: Create Run
      ```
      let runsQuery = RunsQuery(assistantId:  currentAssistantId)
      openAI.runs(threadId: threadsResult.id, query: runsQuery) { result in
@@ -314,6 +316,7 @@ public protocol OpenAIProtocol {
     /**
      This function sends a thread id and run id to the OpenAI API and retrieves a run. The Runs API in this usage enables you to retrieve a run.
 
+     Example: Retrieve Run
      ```
      openAI.runRetrieve(threadId: currentThreadId, runId: currentRunId) { result in
         //Handle response here
@@ -330,7 +333,7 @@ public protocol OpenAIProtocol {
      This function sends a thread id and run id to the OpenAI API and retrieves a threads messages.
      The Thread API in this usage enables you to retrieve a threads messages.
 
-
+     Example: Get Threads Messages
      ```
      openAI.threadsMessages(threadId: currentThreadId, before: nil) { result in
         //Handle response here
@@ -347,6 +350,7 @@ public protocol OpenAIProtocol {
     /**
      This function sends a thread id and message contents to the OpenAI API and returns a run.
 
+     Example: Add Message to Thread
      ```
      let query = ThreadAddMessageQuery(role: message.role.rawValue, content: message.content)
      openAI.threadsAddMessage(threadId: currentThreadId, query: query) { result in
@@ -361,7 +365,20 @@ public protocol OpenAIProtocol {
      **/
     func threadsAddMessage(threadId: String, query: ThreadAddMessageQuery, completion: @escaping (Result<ThreadAddMessageResult, Error>) -> Void)
 
-    // TODO: Files Docs
+    /**
+     This function sends a purpose string, file contents, and fileName contents to the OpenAI API and returns a file id result.
+
+     Example: Upload file
+     ```
+     let query = FilesQuery(purpose: "assistants", file: fileData, fileName: url.lastPathComponent, contentType: "application/pdf")
+     openAI.files(query: query) { result in
+        //Handle response here
+     }
+     ```
+     - Parameter query: The `FilesQuery` instance, containing the information required for the files request.
+     - Parameter completion: The completion handler to be executed upon completion of the files request.
+                          Returns a `Result` of type `FilesResult` if successful, or an `Error` if an error occurs.
+     **/
     func files(query: FilesQuery, completion: @escaping (Result<FilesResult, Error>) -> Void)
 
     // END new functionality added to OpenAI Beta on 11-06-23 end

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -230,4 +230,29 @@ public protocol OpenAIProtocol {
                          Returns a `Result` of type `AudioTranslationResult` if successful, or an `Error` if an error occurs.
      **/
     func audioTranslations(query: AudioTranslationQuery, completion: @escaping (Result<AudioTranslationResult, Error>) -> Void)
+    
+    //1106
+
+    // TODO: Assistant Docs
+    func assistants(query: AssistantsQuery?, method: String, completion: @escaping (Result<AssistantsResult, Error>) -> Void)
+    
+    // TODO: Threads Docs
+    func threads(query: ThreadsQuery, completion: @escaping (Result<ThreadsResult, Error>) -> Void)
+
+    // TODO: Runs Docs
+    func runs(threadId: String, query: RunsQuery, completion: @escaping (Result<RunsResult, Error>) -> Void)
+
+    // TODO: Runs Retrieve Docs
+    func runRetrieve(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void)
+
+    // TODO: Threads Messages Docs
+    func threadsMessages(threadId: String, before: String?, completion: @escaping (Result<ThreadsMessagesResult, Error>) -> Void)
+
+    // TODO: Threads Add Message Docs
+    func threadsAddMessage(threadId: String, query: ThreadAddMessageQuery, completion: @escaping (Result<ThreadAddMessageResult, Error>) -> Void)
+
+    // TODO: Files Docs
+    func files(query: FilesQuery, completion: @escaping (Result<FilesResult, Error>) -> Void)
+
+    // 1106 end
 }

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -347,6 +347,23 @@ public protocol OpenAIProtocol {
     func runRetrieve(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void)
 
     /**
+     This function sends a thread id and run id to the OpenAI API and retrieves a run. The Runs API in this usage enables you to retrieve a run.
+
+     Example: Retrieve Run Steps
+     ```
+     openAI.runRetrieveSteps(threadId: currentThreadId, runId: currentRunId) { result in
+        //Handle response here
+     }
+     ```
+     - Parameter threadId: The thread id for the thread to run.
+     - Parameter runId: The run id for the run to retrieve.
+     - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
+                          Returns a `Result` of type `RunRetreiveStepsResult` if successful, or an `Error` if an error occurs.
+     **/
+    func runRetrieveSteps(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void)
+
+
+    /**
      This function sends a thread id and run id to the OpenAI API and retrieves a threads messages.
      The Thread API in this usage enables you to retrieve a threads messages.
 

--- a/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
+++ b/Sources/OpenAI/Public/Protocols/OpenAIProtocol.swift
@@ -347,7 +347,7 @@ public protocol OpenAIProtocol {
     func runRetrieve(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void)
 
     /**
-     This function sends a thread id and run id to the OpenAI API and retrieves a run. The Runs API in this usage enables you to retrieve a run.
+     This function sends a thread id and run id to the OpenAI API and retrieves a list of run steps. The Runs API in this usage enables you to retrieve a runs run steps.
 
      Example: Retrieve Run Steps
      ```
@@ -357,10 +357,11 @@ public protocol OpenAIProtocol {
      ```
      - Parameter threadId: The thread id for the thread to run.
      - Parameter runId: The run id for the run to retrieve.
+     - Parameter before: String?: The message id for the run step that defines your place in the list of run steps. Pass nil to get all.
      - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
                           Returns a `Result` of type `RunRetreiveStepsResult` if successful, or an `Error` if an error occurs.
      **/
-    func runRetrieveSteps(threadId: String, runId: String, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void)
+    func runRetrieveSteps(threadId: String, runId: String, before: String?, completion: @escaping (Result<RunRetreiveStepsResult, Error>) -> Void)
 
 
     /**
@@ -375,7 +376,7 @@ public protocol OpenAIProtocol {
      ```
 
      - Parameter threadId: The thread id for the thread to run.
-     - Parameter before: String?: The message id for the message taht defines your place in the list of messages. Pass nil to get all.
+     - Parameter before: String?: The message id for the message that defines your place in the list of messages. Pass nil to get all.
      - Parameter completion: The completion handler to be executed upon completion of the runRetrieve request.
                           Returns a `Result` of type `ThreadsMessagesResult` if successful, or an `Error` if an error occurs.
      **/

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -351,21 +351,37 @@ class OpenAITests: XCTestCase {
 
     // 1106
     func testAssistantQuery() async throws {
-        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
-        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.")], tools: [])
+        let query = AssistantsQuery(model: .gpt4_1106_preview, name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: nil, fileIds: nil)], tools: [])
         try self.stub(result: expectedResult)
 
-        let result = try await openAI.assistants(query: query, method: "POST")
+        let result = try await openAI.assistants(query: query, method: "POST", after: nil)
         XCTAssertEqual(result, expectedResult)
     }
 
     func testAssistantQueryError() async throws {
-        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+        let query = AssistantsQuery(model: .gpt4_1106_preview, name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
 
         let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
         self.stub(error: inError)
 
-        let apiError: APIError = try await XCTExpectError { try await openAI.assistants(query: query, method: "POST") }
+        let apiError: APIError = try await XCTExpectError { try await openAI.assistants(query: query, method: "POST", after: nil) }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testListAssistantQuery() async throws {
+        let expectedResult = AssistantsResult(id: nil, data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: nil, fileIds: nil)], tools: nil)
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.assistants(query: nil, method: "GET", after: nil)
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testListAssistantQueryError() async throws {
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.assistants(query: nil, method: "GET", after: nil) }
         XCTAssertEqual(inError, apiError)
     }
 

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -476,6 +476,13 @@ class OpenAITests: XCTestCase {
         let completionsURL = openAI.buildRunRetrieveURL(path: .runRetrieve, threadId: "thread_4321", runId: "run_1234")
         XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/threads/thread_4321/runs/run_1234"))
     }
+
+    func testCustomRunRetrieveStepsURLBuilt() {
+        let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", host: "my.host.com", timeoutInterval: 14)
+        let openAI = OpenAI(configuration: configuration, session: self.urlSession)
+        let completionsURL = openAI.buildRunRetrieveURL(path: .runRetrieveSteps, threadId: "thread_4321", runId: "run_1234")
+        XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/threads/thread_4321/runs/run_1234/steps"))
+    }
     // 1106 end
 }
 

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -33,7 +33,7 @@ class OpenAITests: XCTestCase {
         let result = try await openAI.completions(query: query)
         XCTAssertEqual(result, expectedResult)
     }
-    
+
     func testCompletionsAPIError() async throws {
         let query = CompletionsQuery(model: .textDavinci_003, prompt: "What is 42?", temperature: 0, maxTokens: 100, topP: 1, frequencyPenalty: 0, presencePenalty: 0, stop: ["\\n"])
         let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
@@ -348,6 +348,110 @@ class OpenAITests: XCTestCase {
         let completionsURL = openAI.buildURL(path: .completions)
         XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/completions"))
     }
+
+    // 1106
+    func testAssistantQuery() async throws {
+        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.")], tools: [])
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.assistants(query: query, method: "POST")
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testAssistantQueryError() async throws {
+        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.assistants(query: query, method: "POST") }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testThreadsQuery() async throws {
+        let query = ThreadsQuery(messages: [Chat(role: .user, content: "Hello, What is AI?")])
+        let expectedResult = ThreadsResult(id: "thread_1234")
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.threads(query: query)
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testThreadsQueryError() async throws {
+        let query = ThreadsQuery(messages: [Chat(role: .user, content: "Hello, What is AI?")])
+
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.threads(query: query) }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testRunsQuery() async throws {
+        let query = RunsQuery(assistantId: "asst_7654321")
+        let expectedResult = RunsResult(id: "run_1234")
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.runs(threadId: "thread_1234", query: query)
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testRunsQueryError() async throws {
+        let query = RunsQuery(assistantId: "asst_7654321")
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.runs(threadId: "thread_1234", query: query) }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testRunRetrieveQuery() async throws {
+        let expectedResult = RunRetreiveResult(status: "in_progress")
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.runRetrieve(threadId: "thread_1234", runId: "run_1234")
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testRunRetrieveQueryError() async throws {
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.runRetrieve(threadId: "thread_1234", runId: "run_1234") }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testThreadsMessageQuery() async throws {
+        let expectedResult = ThreadsMessagesResult(data: [ThreadsMessagesResult.ThreadsMessage(id: "thread_1234", role: Chat.Role.user.rawValue, content: [ThreadsMessagesResult.ThreadsMessage.ThreadsMessageContent(type: "text", text: ThreadsMessagesResult.ThreadsMessage.ThreadsMessageContent.ThreadsMessageContentText(value: "Hello, What is AI?"))])])
+        try self.stub(result: expectedResult)
+
+        let result = try await openAI.threadsMessages(threadId: "thread_1234", before: nil)
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testThreadsMessageQueryError() async throws {
+        let inError = APIError(message: "foo", type: "bar", param: "baz", code: "100")
+        self.stub(error: inError)
+
+        let apiError: APIError = try await XCTExpectError { try await openAI.threadsMessages(threadId: "thread_1234", before: nil) }
+        XCTAssertEqual(inError, apiError)
+    }
+
+    func testCustomRunsURLBuilt() {
+        let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", host: "my.host.com", timeoutInterval: 14)
+        let openAI = OpenAI(configuration: configuration, session: self.urlSession)
+        let completionsURL = openAI.buildRunsURL(path: .runs, threadId: "thread_4321")
+        XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/threads/thread_4321/runs"))
+    }
+
+    func testCustomRunsRetrieveURLBuilt() {
+        let configuration = OpenAI.Configuration(token: "foo", organizationIdentifier: "bar", host: "my.host.com", timeoutInterval: 14)
+        let openAI = OpenAI(configuration: configuration, session: self.urlSession)
+        let completionsURL = openAI.buildRunRetrieveURL(path: .runRetrieve, threadId: "thread_4321", runId: "run_1234")
+        XCTAssertEqual(completionsURL, URL(string: "https://my.host.com/v1/threads/thread_4321/runs/run_1234"))
+    }
+    // 1106 end
 }
 
 @available(tvOS 13.0, *)

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -123,6 +123,57 @@ final class OpenAITestsCombine: XCTestCase {
         let result = try awaitPublisher(openAI.audioTranslations(query: query))
         XCTAssertEqual(result, transcriptionResult)
     }
+
+    // 1106
+    func testAssistantQuery() throws {
+        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.")], tools: [])
+        try self.stub(result: expectedResult)
+
+        let result = try awaitPublisher(openAI.assistants(query: query, method: "POST"))
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testThreadsQuery() throws {
+        let query = ThreadsQuery(messages: [Chat(role: .user, content: "Hello, What is AI?")])
+        let expectedResult = ThreadsResult(id: "thread_1234")
+
+        try self.stub(result: expectedResult)
+        let result = try awaitPublisher(openAI.threads(query: query))
+
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testRunsQuery() throws {
+        let query = RunsQuery(assistantId: "asst_7654321")
+        let expectedResult = RunsResult(id: "run_1234")
+
+        try self.stub(result: expectedResult)
+        let result = try awaitPublisher(openAI.runs(threadId: "thread_1234", query: query))
+        
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testRunRetrieveQuery() throws {
+        let expectedResult = RunRetreiveResult(status: "in_progress")
+        try self.stub(result: expectedResult)
+
+        let result = try awaitPublisher(openAI.runRetrieve(threadId: "thread_1234", runId: "run_1234"))
+
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func testThreadsMessageQuery() throws {
+        let expectedResult = ThreadsMessagesResult(data: [ThreadsMessagesResult.ThreadsMessage(id: "thread_1234", role: Chat.Role.user.rawValue, content: [ThreadsMessagesResult.ThreadsMessage.ThreadsMessageContent(type: "text", text: ThreadsMessagesResult.ThreadsMessage.ThreadsMessageContent.ThreadsMessageContentText(value: "Hello, What is AI?"))])])
+        try self.stub(result: expectedResult)
+
+        let result = try awaitPublisher(openAI.threadsMessages(threadId: "thread_1234", before: nil))
+
+        XCTAssertEqual(result, expectedResult)
+    }
+    // 1106 end
+
+
 }
 
 @available(tvOS 13.0, *)

--- a/Tests/OpenAITests/OpenAITestsCombine.swift
+++ b/Tests/OpenAITests/OpenAITestsCombine.swift
@@ -126,11 +126,11 @@ final class OpenAITestsCombine: XCTestCase {
 
     // 1106
     func testAssistantQuery() throws {
-        let query = AssistantsQuery(model: Model("gpt-4-1106-preview"), name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
-        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.")], tools: [])
+        let query = AssistantsQuery(model: .gpt4_1106_preview, name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: [])
+        let expectedResult = AssistantsResult(id: "asst_1234", data: [AssistantsResult.AssistantContent(id: "asst_9876", name: "My New Assistant", description: "Assistant Description", instructions: "You are a helpful assistant.", tools: nil, fileIds: nil)], tools: [])
         try self.stub(result: expectedResult)
 
-        let result = try awaitPublisher(openAI.assistants(query: query, method: "POST"))
+        let result = try awaitPublisher(openAI.assistants(query: query, method: "POST", after: nil))
         XCTAssertEqual(result, expectedResult)
     }
 


### PR DESCRIPTION
Yeah, I'd like to be able to support the assistant features like threads, runs, and files with assistants API.

I have a PR to start to explore the possibilities here.

Six new API endpoints are exposed in the APIPath to support the assistants API. 
```
    static let assistants = "/v1/assistants"
    static let threads = "/v1/threads"
    static let runs = "/v1/threads/THREAD_ID/runs"
    static let runRetrieve = "/v1/threads/THREAD_ID/runs/RUN_ID"
    static let threadsMessages = "/v1/threads/THREAD_ID/messages"
    static let files = "/v1/files"
```
The `OpenAIProtocol` is modified as follows: added
```

    func assistants(query: AssistantsQuery?, method: String, completion: @escaping (Result<AssistantsResult, Error>) -> Void)
    

    func threads(query: ThreadsQuery, completion: @escaping (Result<ThreadsResult, Error>) -> Void)


    func runs(threadId: String, query: RunsQuery, completion: @escaping (Result<RunsResult, Error>) -> Void)


    func runRetrieve(threadId: String, runId:String, completion: @escaping (Result<RunRetreiveResult, Error>) -> Void)


    func threadsMessages(threadId: String, before: String?, completion: @escaping (Result<ThreadsMessagesResult, Error>) -> Void)


    func threadsAddMessage(threadId: String, query: ThreadAddMessageQuery, completion: @escaping (Result<ThreadAddMessageResult, Error>) -> Void)


    func files(query: FilesQuery, completion: @escaping (Result<FilesResult, Error>) -> Void)
```

### Assistants:
- [X] Create 
- [x] Modify
- [X] Attach 1 file (PDF only currently)
  -  [ ] Attach up to 10(20) files of all supported OpenAI types.
- [X] List assistants
  - [x] Paging through assistants list

### Tools can be passed to assistant creation.
- [X] Code Interpreter 
- [X] Retrieval
- [ ] Functions

### Threads/Runs
- [X] Create Thread
- [X] Create Run
- [X] Retrieve Run
- [X] Add Message to Thread
- [X] Retrieve Threads Messages
  - [ ] Paging through messages in a thread 

### Files
- [X] Upload
- [ ] Delete
- [ ] List

### Example App:

A new demonstration of the assistants API and its requirements of the polling has been added to the Demo app.

- Now you can create a new assistant on the Chats tab by selecting "+" -> New Assistant -> Fill in details -> OK.
This should result in a "New Assistant" row being added to the chats, you can chat with your newly created assistant in this conversation.

- You can now list your OpenAI API Assistants on the "Assistants" tab. Select "+" -> Get Assistants to load the assistants list.

* I've implemented the file upload and assistant creation with up to 1 PDF. (For now, will be fixed to add support for all of OpenAIs supported file types.)

Create Assistant
![createAssistant](https://github.com/MacPaw/OpenAI/assets/11546477/4c8a16d6-2094-4e50-b5d2-53bbd01ddf3f)

Chat with Assistant in thread
![chatThread](https://github.com/MacPaw/OpenAI/assets/11546477/8e2cb4b6-0bef-4259-9e08-de2913a00e71)

List assistants
![listAssistants](https://github.com/MacPaw/OpenAI/assets/11546477/e2cd2938-6af8-45c5-9e93-1603061fedc4)

**Describe the solution you'd like**
Support for Assistants, Threads, Runs, Run Retrieval, Fetching messages from threads, and uploading files to OpenAI API.

